### PR TITLE
Support includes/does not include operator in conditions

### DIFF
--- a/rdrf/rdrf/forms/dsl/constants.py
+++ b/rdrf/rdrf/forms/dsl/constants.py
@@ -9,7 +9,7 @@ CDE:/\\w+/
 target.2: FORM_OR_SECTION? CDE+
 boolean_operator.4: BOOLEAN_OPERATOR~1
 BOOLEAN_OPERATOR: "and" | "or"
-OPERATOR: ">="| "<=" | "==" | "!=" | "<" | ">" | "is"
+OPERATOR: ">="| "<=" | "==" | "!=" | "<" | ">" | "is" | "includes" | "does not include"
 action.1: ACTION~1
 ACTION: "visible" | "hidden" | "enabled" | "disabled"
 %import common.WS
@@ -39,3 +39,5 @@ INVERSE_ACTION_MAP = {
 QUALIFIERS = ["section", "form"]
 
 PREDEFINED_VALUES = ["set", "unset"]
+
+INCLUDE_OPERATORS = ["includes", "does not include"]

--- a/rdrf/rdrf/static/js/form_dsl.js
+++ b/rdrf/rdrf/static/js/form_dsl.js
@@ -144,6 +144,14 @@ function test_cde_value(name, base_name, op, value) {
                 return equal_len && cde_values.find(function(value) { return !target_values.includes(value);}) === undefined;
             case "!=":
                 return !equal_len || cde_values.find(function(value) { return !target_values.includes(value);}) !== undefined;
+            case "includes":
+                return cde_values.some(function(el) {
+                    return target_values.includes(el);
+                 });
+            case "does not include":
+                return cde_values.every( function(el) {
+                    return !target_values.includes(el);
+                });
         }
     }
 }

--- a/rdrf/rdrf/templates/rdrf_cdes/form-dsl-help.html
+++ b/rdrf/rdrf/templates/rdrf_cdes/form-dsl-help.html
@@ -45,9 +45,17 @@
         <li>&gt;=</li>
         <li>&lt;=</li>
         <li>is</li>
+        <li>includes</li>
+        <li>does not include</li>
     </ul>
 
-    <em>{% trans "Note: When using" %}<code>is</code> {% trans "the only 2 values supported are" %}<code>set</code> {% trans "or" %}<code>unset</code>{% trans "(ie. is the CDE set to any value, respectively not set to any value.)" %}</em>
+    <em>
+        {% trans "Note:" %}
+        <br/>
+        {% trans "When using" %}<code>is</code> {% trans "the only 2 values supported are" %}<code>set</code> {% trans "or" %}<code>unset</code>{% trans "(ie. is the CDE set to any value, respectively not set to any value.)" %}</em>
+        <br/>
+        {% trans "When using" %}<code>includes/does not include</code> {% trans "the CDE on which the operator is applied need to allow multiple values" %}
+    </em>
 
     <br/>
     <br/>
@@ -92,6 +100,17 @@
         {% trans "This rule states that" %} ANGAllergySpecify {%trans "CDE" %}  {% trans "should be hidden if " %} ANGAllergiesType {%trans "does not have any value set" %}
         <br/>
     </p>
+    <code>ANGAllergySpecify hidden if ANGAllergiesType includes Other</code>
+    <p>
+        {% trans "This rule states that" %} ANGAllergySpecify {%trans "CDE" %}  {% trans "should be hidden if " %} ANGAllergiesType {%trans "includes the value" %} Other
+        <br/>
+    </p>
+    <code>ANGAllergySpecify hidden if ANGAllergiesType does not include "Other, Food"</code>
+    <p>
+        {% trans "This rule states that" %} ANGAllergySpecify {%trans "CDE" %}  {% trans "should be hidden if " %} ANGAllergiesType {%trans "does not include the values" %} Other {%trans "or" %} Food
+        <br/>
+    </p>
+
 
 
 


### PR DESCRIPTION
This MR adds support for includes / does not include operators for conditions in which CDEs with multiple values appear.