### PR TITLE
[TRRFFDA-559] Conditional Rendering of the same CDE in 2 different sections generates an error

### DIFF
--- a/rdrf/rdrf/forms/dsl/parse_operations.py
+++ b/rdrf/rdrf/forms/dsl/parse_operations.py
@@ -14,12 +14,12 @@ class Target:
 
     def invalid_cdes(self):
         if self.has_qualifier:
-            sections = set(s.cde for s in self.target_cdes)
-            valid_sections = set(s.cde for s in self.target_cdes if s.cde in self.section_helper.get_section_codes())
+            sections = set(s for s in self.target_cdes)
+            valid_sections = set(s for s in self.target_cdes if s.cde in self.section_helper.get_section_codes())
             return sections - valid_sections
 
-        cdes = set(target.cde for target in self.target_cdes)
-        valid_cdes = set(target.cde for target in self.target_cdes if target.is_valid_cde())
+        cdes = set(target for target in self.target_cdes)
+        valid_cdes = set(target for target in self.target_cdes if target.is_valid_cde())
         return set(cdes) - valid_cdes
 
     def get_section_code(self):

--- a/rdrf/rdrf/forms/dsl/parse_utils.py
+++ b/rdrf/rdrf/forms/dsl/parse_utils.py
@@ -231,6 +231,11 @@ class EnrichedCDE:
     def is_multi_section(self):
         return self.get_cde_info().is_multi_section
 
+    def has_valid_section(self):
+        if self.section:
+            return self.section in self.cde_helper.section_names_dict
+        return True
+
     def is_valid_cde(self):
         return self.get_key() in self.cde_helper.cde_names_dict
 

--- a/rdrf/rdrf/testing/unit/form_dsl_tests.py
+++ b/rdrf/rdrf/testing/unit/form_dsl_tests.py
@@ -296,7 +296,19 @@ class FormDSLValidationTestCase(FormTestCase):
         self.check_error_messages(
             exc_info,
             1,
-            ['Invalid condition specified on line 1 : CDEAge2']
+            ['Invalid condition cdes specified on line 1 : CDEAge2']
+        )
+
+    def test_simple_condition_with_invalid_section_prefix(self):
+        with self.assertRaises(ValidationError) as exc_info:
+            self.new_form.conditional_rendering_rules = '''
+            DM1Cholesterol:DM1ChronicInfection visible if section:CDEAge == 18
+            '''
+            self.new_form.save()
+        self.check_error_messages(
+            exc_info,
+            1,
+            ['Invalid condition cdes specified on line 1 : Invalid section "section" in section:CDEAge']
         )
 
     def test_simple_condition_with_section_prefix_invalid_section_prefix(self):
@@ -308,7 +320,7 @@ class FormDSLValidationTestCase(FormTestCase):
         self.check_error_messages(
             exc_info,
             1,
-            ['Invalid CDEs specified on line 1 : DM1ChronicInfection']
+            ['Invalid CDEs specified on line 1 : Invalid section "DM1" in DM1:DM1ChronicInfection']
         )
 
     def test_multi_section_condition_and_targets_same_section_with_section_prefix(self):


### PR DESCRIPTION
Actually the error in the ticket is due to using an incorrect section name. This PR improves the error messages of the DSL validation for that kind of scenarios.