### PR TITLE
[TRRFFDA-557] Fix history popup dimensions on mobile displays

### DIFF
--- a/rdrf/rdrf/templates/proms/proms_clinical.html
+++ b/rdrf/rdrf/templates/proms/proms_clinical.html
@@ -105,7 +105,7 @@
 
 <!-- modal popup -->
 <div class="modal fade" id="new_survey_request_modal" tabindex="-1" role="dialog" aria-labelledby="new_survey_request_label" aria-hidden="true">
-  <div class="modal-dialog" role="document">
+  <div class="modal-dialog modal-lg" role="document">
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title" id="new_survey_request_label">New Survey Request</h5>

--- a/rdrf/rdrf/templates/rdrf_cdes/archive_modal.html
+++ b/rdrf/rdrf/templates/rdrf_cdes/archive_modal.html
@@ -4,7 +4,7 @@
 {% if show_archive_button %}
 	<!-- Modal for deleting patient -->
 	<div class="modal fade" id="archive_modal" tabindex="-1" role="dialog" aria-labelledby="archive_button_modal_label">
-	  <div class="modal-dialog" role="document">
+	  <div class="modal-dialog modal-lg" role="document">
 	    <div class="modal-content">
 	      <div class="modal-header">
 		<button type="button" class="close" data-dismiss="modal" aria-label="Cancel"><span aria-hidden="true">&times;</span></button>

--- a/rdrf/rdrf/templates/rdrf_cdes/form_field_history.html
+++ b/rdrf/rdrf/templates/rdrf_cdes/form_field_history.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <div class="modal fade" tabindex="-1" role="dialog" aria-labelledby="fieldHistoryModalLabel">
-  <div class="modal-dialog" role="document">
+  <div class="modal-dialog modal-lg" role="document">
     <div class="modal-content">
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>


### PR DESCRIPTION
Update that applies `modal-lg` to all modal windows, to be consistent.