### PR TITLE
[TRRFFDA-558] Fix progression arrows on mobile displays

### DIFF
--- a/rdrf/rdrf/templates/proms/proms_clinical.html
+++ b/rdrf/rdrf/templates/proms/proms_clinical.html
@@ -39,11 +39,11 @@
 
 {% block content %}
 
-			<a class="previous-form" href="{{ previous_form_link }}">
+			<a class="previous-form hidden-sm hidden-xs" href="{{ previous_form_link }}">
 				<span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
 			</a>
 
-			<a class="next-form" href="{{ next_form_link }}">
+			<a class="next-form hidden-sm hidden-xs" href="{{ next_form_link }}">
 				<span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
 			</a>
     <br>

--- a/rdrf/rdrf/templates/rdrf_cdes/clinician.html
+++ b/rdrf/rdrf/templates/rdrf_cdes/clinician.html
@@ -89,11 +89,11 @@
 
 {% block content %}
 
-			<a class="previous-form" href="{{ previous_form_link }}">
+			<a class="previous-form hidden-sm hidden-xs" href="{{ previous_form_link }}">
 				<span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
 			</a>
 
-			<a class="next-form" href="{{ next_form_link }}">
+			<a class="next-form hidden-sm hidden-xs" href="{{ next_form_link }}">
 				<span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
 			</a>
     <div class="row">

--- a/rdrf/rdrf/templates/rdrf_cdes/custom_consent_form.html
+++ b/rdrf/rdrf/templates/rdrf_cdes/custom_consent_form.html
@@ -125,20 +125,20 @@
 
 	{% if patient|has_feature:"consent_lock" %}
 		{% if consent %}
-			<a class="previous-form" href="{{ previous_form_link }}">
+			<a class="previous-form hidden-sm hidden-xs" href="{{ previous_form_link }}">
 				<span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
 			</a>
 
-			<a class="next-form" href="{{ next_form_link }}">
+			<a class="next-form hidden-sm hidden-xs" href="{{ next_form_link }}">
 				<span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
 			</a>
 		{% endif %}
 	{% else %}
-		<a class="previous-form" href="{{ previous_form_link }}">
+		<a class="previous-form hidden-sm hidden-xs" href="{{ previous_form_link }}">
 			<span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
 		</a>
 
-		<a class="next-form" href="{{ next_form_link }}">
+		<a class="next-form hidden-sm hidden-xs" href="{{ next_form_link }}">
 			<span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
 		</a>
 	{% endif %}

--- a/rdrf/rdrf/templates/rdrf_cdes/form.html
+++ b/rdrf/rdrf/templates/rdrf_cdes/form.html
@@ -300,11 +300,11 @@
 {% block content %}
     {{ block.super }}
 
-	<a class="previous-form" href="{{ previous_form_link }}">
+	<a class="previous-form hidden-sm hidden-xs" href="{{ previous_form_link }}">
 		<span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
 	</a>
 
-	<a class="next-form" href="{{ next_form_link }}">
+	<a class="next-form hidden-sm hidden-xs" href="{{ next_form_link }}">
 		<span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
 	</a>
 

--- a/rdrf/rdrf/templates/rdrf_cdes/form_readonly.html
+++ b/rdrf/rdrf/templates/rdrf_cdes/form_readonly.html
@@ -219,11 +219,11 @@
 {% block content %}<br>
     <div class="alert alert-danger">This form is readonly</div>
     {{ block.super }}
-    	<a class="previous-form" href="{{ previous_form_link }}">
+    	<a class="previous-form hidden-sm hidden-xs" href="{{ previous_form_link }}">
 		<span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
 	</a>
 
-	<a class="next-form" href="{{ next_form_link }}">
+	<a class="next-form hidden-sm hidden-xs" href="{{ next_form_link }}">
 		<span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
 	</a>
 

--- a/rdrf/rdrf/templates/rdrf_cdes/patient_edit.html
+++ b/rdrf/rdrf/templates/rdrf_cdes/patient_edit.html
@@ -192,11 +192,11 @@
                 {% include 'rdrf_cdes/archive_modal.html' %}
 
 
-	<a class="previous-form" href="{{ previous_form_link }}">
+	<a class="previous-form hidden-sm hidden-xs" href="{{ previous_form_link }}">
 		<span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
 	</a>
 
-	<a class="next-form" href="{{ next_form_link }}">
+	<a class="next-form hidden-sm hidden-xs" href="{{ next_form_link }}">
 		<span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
 	</a>
 


### PR DESCRIPTION
Hides progression arrows on mobile displays.

We can move them to the sidebar but I think we should also delay that until after the angelman merge as the arrows are spread across many templates rather than being blocks in the base templates.