### PR TITLE
[CDAP-155] Use SameSite Lax just on the reset password page but use SameSite Strict everywhere else

### DIFF
--- a/rdrf/rdrf/settings.py
+++ b/rdrf/rdrf/settings.py
@@ -150,6 +150,7 @@ MIDDLEWARE = (
     'django.middleware.common.CommonMiddleware',
     'registry.common.middleware.NoCacheMiddleware',
     'csp.middleware.CSPMiddleware',
+    'registry.common.middleware.LaxSameSiteCookieMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -309,7 +310,7 @@ SESSION_COOKIE_SECURE = env.get("session_cookie_secure", PRODUCTION)
 SESSION_COOKIE_NAME = env.get(
     "session_cookie_name", "trrf_{0}".format(SCRIPT_NAME.replace("/", "")))
 SESSION_COOKIE_DOMAIN = env.get("session_cookie_domain", "") or None
-# SESSION_COOKIE_SAMESITE = "Strict"
+SESSION_COOKIE_SAMESITE = "Strict"
 SESSION_EXPIRE_AT_BROWSER_CLOSE = True
 
 CSRF_COOKIE_NAME = env.get("csrf_cookie_name", "csrf_{0}".format(SESSION_COOKIE_NAME))


### PR DESCRIPTION
Tested and it works + fixes the issue.

Interestingly, the cookie eventually gets stored on the page as 'Strict' because subsequent requests change the value back.