### PR TITLE
Added missing js for collapsing panels to base template

### DIFF
--- a/rdrf/rdrf/templates/rdrf_cdes/base-1-col.html
+++ b/rdrf/rdrf/templates/rdrf_cdes/base-1-col.html
@@ -44,6 +44,7 @@
     <script type="text/javascript" src="{% url 'javascript-catalog' %}"></script>
     <script type="text/javascript" src="{% static 'js/rpc_module.js' %}"></script>
     <script type="text/javascript" src="{% static 'js/rdrf.js' %}"></script>
+    <script type="text/javascript" src="{% static 'js/collapsing_panels.js' %}"></script>
     <script type="text/javascript">var django = { $: $.noConflict() }; if (!$) $ = django.$; </script>
 
     {% block extrastyle %}


### PR DESCRIPTION
This fixes a bug on the page for adding a new patient. Due to missing collapsing_panels.js the user cannot add a Patient Address.