### PR TITLE
[ERE-199] Failed parent_edit reversal

### DIFF
--- a/rdrf/rdrf/templates/rdrf_cdes/navbar_links.html
+++ b/rdrf/rdrf/templates/rdrf_cdes/navbar_links.html
@@ -73,7 +73,7 @@
                             {% trans 'Admin Page' %}</a></li>
                         <li class="divider"></li>
                     {% endif %}
-                    {% if request.user.is_parent and registry_code %}
+                    {% if request.user.is_parent and registry_code and parent %}
                         <li><a href="{% url 'registry:parent_edit' registry_code parent.id %}"><span
                                 class="glyphicon glyphicon-wrench"></span>
                             {% trans 'Account' %}</a></li>


### PR DESCRIPTION
New navbar links are causing `/ang` to fail to load when logging in on angelman dev:

```
django.urls.exceptions.NoReverseMatch: Reverse for 'parent_edit' with arguments '('ang', '')' not found. 1 pattern(s) tried: ['patients/(?P<registry_code>\\w+)/parent/(?P<parent_id>\\d+)/?$']
```

This PR checks if `parent` is set in the template before reversing