### PR TITLE
Unit Test Coverage Report

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,7 @@
 [run]
 omit =
   */migrations/*.py
+
+[html]
+title = TRRF Unit Test Coverage
+directory = /data/unittest_coverage_report

--- a/docker/dev/docker-entrypoint.sh
+++ b/docker/dev/docker-entrypoint.sh
@@ -247,6 +247,23 @@ if [ "$1" = 'runtests' ]; then
     exec pytest $args
 fi
 
+# runtests with coverage entrypoint
+if [ "$1" = 'runtests_coverage' ]; then
+    info "[Run] Starting tests"
+    export DJANGO_SETTINGS_MODULE="${DJANGO_SETTINGS_MODULE}"_test
+
+    set -x
+    args="rdrf/rdrf/testing/unit"
+    if [ "$2" != "" ]; then
+        # pass through any arguments (if provided) to pytest
+        args="${@:2}"
+    fi
+    cd /app
+    coverage run -m pytest $args
+    coverage report -m
+    exec coverage html
+fi
+
 # aloe entrypoint
 if [ "$1" = 'aloe' ]; then
     info "[Run] Starting aloe"
@@ -264,7 +281,7 @@ if [ "$1" = 'db_init' ]; then
     exit
 fi
 
-warn "[RUN]: Builtin command not provided [tarball|aloe|runtests|runserver|runserver_plus|uwsgi|uwsgi_local|db_init]"
+warn "[RUN]: Builtin command not provided [tarball|aloe|runtests|runtests_coverage|runserver|runserver_plus|uwsgi|uwsgi_local|db_init]"
 info "[RUN]: $*"
 
 set -x

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -13,3 +13,4 @@ unittest-xml-reporting==2.5.2
 requests==2.25.1
 sqlalchemy-utils==0.36.1
 stellar==0.4.5
+coverage==5.5

--- a/scripts/unit-tests-coverage.sh
+++ b/scripts/unit-tests-coverage.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+docker-compose -f docker-compose-teststack-base.yml -f docker-compose-teststack-dev.yml run --rm serverundertest runtests_coverage $@
+RESULT=$?
+
+docker-compose -f docker-compose-teststack-base.yml -f docker-compose-teststack-dev.yml stop
+
+exit $RESULT


### PR DESCRIPTION
Configured a new shell script process for getting unit test coverage. This flow generates an HTML under data directory which would be helpful for developers to get the unit test coverage report. Please look if this works. Attached a few screenshots of HTML Report.
<img width="900" alt="Screenshot 2021-06-20 at 9 29 26 PM" src="https://user-images.githubusercontent.com/31698165/122680807-c0be3c80-d20e-11eb-8a0f-a6ff5b967837.png">
<img width="1692" alt="Screenshot 2021-06-20 at 9 29 56 PM" src="https://user-images.githubusercontent.com/31698165/122680808-c3b92d00-d20e-11eb-9e1c-c001cd7da2ef.png">
