### PR TITLE
[ERE-1638] Replace email error reporting

### DIFF
--- a/rdrf/rdrf/helpers/log.py
+++ b/rdrf/rdrf/helpers/log.py
@@ -1,0 +1,33 @@
+from django.utils.log import AdminEmailHandler
+from logging import StreamHandler
+
+
+# An AdminEmainHandler that removes potentially sensitive information from the Error emails
+# sent to Django Admins.
+class AdminShortEmailHandler(AdminEmailHandler):
+    def send_mail(self, subject, message, *args, **kwargs):
+        try:
+            message = message[:message.index('\nRequest information:')]
+        except ValueError:
+            pass
+        super().send_mail(subject, message, fail_silently=True)
+
+
+# Can be used to log to stderr all the information that is normally included
+# in the Error emails sent to Django admins.
+class StreamDetailedErrorHandler(StreamHandler):
+    def emit(self, record):
+        email_handler = _NoMailErrorHandler(include_html=False)
+        email_handler.emit(record)
+        msg = '\n'.join((email_handler.subject, email_handler.message))
+
+        record.args = None
+        record.msg = msg
+        super().emit(record)
+
+
+class _NoMailErrorHandler(AdminEmailHandler):
+
+    def send_mail(self, subject, message, *args, **kwargs):
+        self.subject = subject
+        self.message = message

--- a/rdrf/rdrf/settings.py
+++ b/rdrf/rdrf/settings.py
@@ -445,16 +445,21 @@ LOGGING = {
             'class': 'logging.StreamHandler',
             'formatter': 'simple'
         },
+        # Used to log detailed information about unhandled errors when Debug is False
+        'log_detailed_error': {
+            'level': 'ERROR',
+            'filters': ['require_debug_false'],
+            'class': 'rdrf.helpers.log.StreamDetailedErrorHandler',
+        },
         'mail_admins': {
             'level': 'ERROR',
             'filters': ['require_debug_false'],
-            'class': 'django.utils.log.AdminEmailHandler',
-            'include_html': True
+            'class': 'rdrf.helpers.log.AdminShortEmailHandler',
         },
     },
     'loggers': {
         '': {
-            'handlers': ['console'],
+            'handlers': ['console', 'log_detailed_error'],
             'level': 'DEBUG' if DEBUG else 'INFO',
             'propagate': False
         },


### PR DESCRIPTION
@ScriptSmith , can you please have a look if this is something you could work with?

Might need some adjustments, so I left a WIP label on it.

We're still using the python logging mechanism to report the uncaught errors, but:

- the email is shortened to remove information like detailed request info, settings, detailed traceback
- all the details that used to be sent in the email will be logged to the console and will end up in CloudWatch

This way you will still get notified by email about each uncaught error, but the email won't contain any potentially sensitive information.
You could still go to your CloudWatch logs to get all the details that might help in reporducing the error.
