### PR TITLE
[ERE-1485] Improve Multi-File widget

### DIFF
--- a/rdrf/rdrf/forms/widgets/widgets.py
+++ b/rdrf/rdrf/forms/widgets/widgets.py
@@ -445,12 +445,15 @@ class MultipleFileInput(Widget):
         attrs = attrs or {}
         items = self._render_each(name, value, attrs)
 
-        elements = ("<div class=\"row multi-file\">%s</div>" % item for item in items)
+        elements = (f'<div class="row multi-file"><div>{item}</div></div>' for item in items)
+        template = next(elements)
+        divider = '\n<div class="row justify-content-center"><hr class="w-75"></div>\n'
         return """
             <div class="row multi-file-widget" id="%s_id">
-              %s
+                %s
+                %s
             </div>
-        """ % (name, "\n".join(elements))
+        """ % (name, template, divider.join(elements))
 
     class TemplateFile(object):
         url = ""
@@ -460,7 +463,7 @@ class MultipleFileInput(Widget):
 
     def _render_base(self, name, value, attrs, index):
         input_name = self.input_name(name, index)
-        base = widgets.ClearableFileInput().render(input_name, value, attrs)
+        base = CustomFileInput().render(input_name, value, attrs)
         hidden = HiddenInput().render(input_name + "-index", index, {})
         return "%s\n%s" % (base, hidden)
 
@@ -474,7 +477,7 @@ class MultipleFileInput(Widget):
         """
         Gets file input value from each sub-fileinput.
         """
-        base_widget = widgets.ClearableFileInput()
+        base_widget = CustomFileInput()
 
         indices = (self.input_index(name, n, "-index") for n in data)
         clears = (self.input_index(name, n, "-clear") for n in data)
@@ -571,38 +574,38 @@ class SliderWidget(widgets.TextInput):
             widget_attrs = ''
 
         context = f"""
-             <div class="rdrf-cde-slider">
+            <div class="rdrf-cde-slider">
                 <div style="float:left; margin-right:20px;"><b>{_(left_label)}</b></div>
                 <div style="float:left">
                     <input type="hidden" id="{attrs['id']}" name="{name}" value="{value}"/>
                 </div>
                 <div style="float:left;margin-left:20px;"><b>{_(right_label)}</b></div>
-             </div>
-             <br/>
-             <script>
-                 $(function() {{
-                     $( "#{attrs['id']}" ).bootstrapSlider({{
-                         tooltip: 'always',
-                         id: '{attrs['id']}-slider',
-                         value: '{value}',
-                         {widget_attrs}
-                     }});
+            </div>
+            <br/>
+            <script>
+                $(function() {{
+                    $( "#{attrs['id']}" ).bootstrapSlider({{
+                        tooltip: 'always',
+                        id: '{attrs['id']}-slider',
+                        value: '{value}',
+                        {widget_attrs}
+                    }});
 
-                     // Set the uninitialised / null value to ""
-                     $( "#{attrs['id']}" ).val("{value}");
-                     // Set the uninitialised / null value to "-" in the tooltip
-                     if ("{value}" === "") {{
-                         $("#{attrs['id']}-slider .tooltip-inner").html("-");
-                     }};
+                    // Set the uninitialised / null value to ""
+                    $( "#{attrs['id']}" ).val("{value}");
+                    // Set the uninitialised / null value to "-" in the tooltip
+                    if ("{value}" === "") {{
+                        $("#{attrs['id']}-slider .tooltip-inner").html("-");
+                    }};
 
                      // Set z-index to 0 for slider tooltip so it's not displayed through
                      // form headers
-                     $(".slider .tooltip").css("z-index","0");
+                    $(".slider .tooltip").css("z-index","0");
 
                      // Hack to get compatibility for Bootstrap 5 with bootstrap-slider-11.0.2 which only officially supports Bootstrap 4
-                     $(".slider .tooltip .arrow").addClass("tooltip-arrow");
-                 }});
-             </script>
+                    $(".slider .tooltip .arrow").addClass("tooltip-arrow");
+                }});
+            </script>
             """
 
         return context

--- a/rdrf/rdrf/static/js/form.js
+++ b/rdrf/rdrf/static/js/form.js
@@ -245,7 +245,7 @@ function rdrfSetupFileUploads() {
 
     function makeCopy(n) {
       var copy = template.clone().children().each(function() {
-        var elem = $(this);
+        var elem = $(this).children().first();
         _.each(["name", "id", "for"], function(attr) {
           var val = elem.attr(attr);
           if (val) {
@@ -264,20 +264,6 @@ function rdrfSetupFileUploads() {
         .append($('<div class="col-9"></div>').append(input).append(index))
         .append($('<div class="col-3"></div>').append(remove).append(clear.hide()));
     }
-
-    widget.children(".multi-file")
-      .each(function() {
-        var elem = $(this);
-        if (elem.find("a").attr("href")) {
-          var a = elem.find("a").addClass("col-9");
-          var cb = elem.find("input[type='checkbox']")
-              .addClass("form-check-input")
-              .wrap('<div class="col-3"><div class="form-check"><label></label></div></div>')
-              .after("Clear").parent().parent().parent();
-          var index = elem.find("input[type='hidden']");
-          elem.empty().append(a).append(cb).append(index);
-        }
-      });
 
     var nextIndex = function() {
       var indices = widget.find("input[type='hidden']")

--- a/rdrf/rdrf/templates/widgets/custom_file_input.html
+++ b/rdrf/rdrf/templates/widgets/custom_file_input.html
@@ -30,9 +30,19 @@
         {% if widget.virus_check_result == 'scanning' %}
             setup_virus_status_check("{{widget.value.url}}","{{widget.virus_check_id}}", "{{widget.value}}", 5000);
         {% endif %}
+
+        $("#{{ widget.checkbox_id }}").change(function(event) {
+          var fileInput = $("#{{ widget.attrs.id }}");
+          if (this.checked) {
+            fileInput.val('');
+          }
+          fileInput.prop('disabled', this.checked);
+        });
+
     </script>
     <div>
         {{ widget.input_text }}:
     </div>
 {% endif %}
 <input type="{{ widget.type }}" name="{{ widget.name }}"{% include "django/forms/widgets/attrs.html" %}>
+


### PR DESCRIPTION
- Include virus scanning progress, similar to single-file widget
- Open files in new tab / a download prompt, rather than in the same tab.

Additionally:

- Adds the ability to Change an existing file upload (in the current version you can only Clear the existing files, caused by a JS bug)
- Tries to reduce server-side validation error caused by a user selecting a new file and deleting the exiting one by disabling and clearing the select file control when the Clear checkbox gets checked. 