### PR TITLE
[ERE-1621] Create FieldValue records as required during reporting, not during save

### DIFF
--- a/rdrf/explorer/utils.py
+++ b/rdrf/explorer/utils.py
@@ -221,6 +221,11 @@ class DatabaseUtils(object):
                     for context_id in context_models:
                         row = copy(row_dict)
                         # row["context_id"] = context_id
+                        create_field_values(
+                            self.registry_model,
+                            Patient.objects.get(id=patient_id),
+                            RDRFContext.objects.get(id=context_id)
+                        )
                         qry = q.filter(patient_id=patient_id, context_id=context_id)
                         self._get_fvs_by_datatype(qry, row)
                         yield row

--- a/rdrf/rdrf/views/form_view.py
+++ b/rdrf/rdrf/views/form_view.py
@@ -38,7 +38,6 @@ from rdrf.helpers.utils import consent_status_for_patient
 
 from rdrf.db.contexts_api import RDRFContextManager
 from rdrf.db.contexts_api import RDRFContextError
-from explorer.utils import create_field_values
 
 
 from django.shortcuts import redirect
@@ -727,20 +726,6 @@ class FormView(View):
                 form_user=self.request.user.username)
             xray_recorder.end_subsegment()
 
-            xray_recorder.begin_subsegment("report_fields")
-            # save report friendly field values
-            try:
-                logger.debug("trying to create field values for %s" % patient)
-                if self.rdrf_context:
-                    create_field_values(registry,
-                                        patient,
-                                        self.rdrf_context)
-                logger.debug("created field values for patient %s" % patient)
-            except Exception as ex:
-                logger.debug("error creating field values: %s" % ex)
-                raise
-            xray_recorder.end_subsegment()
-
             if self.CREATE_MODE and dyn_patient.rdrf_context_id != "add":
                 xray_recorder.begin_subsegment("existing_form")
                 # we've created the context on the fly so no redirect to the edit view on
@@ -748,13 +733,6 @@ class FormView(View):
                 newly_created_context = RDRFContext.objects.get(id=dyn_patient.rdrf_context_id)
                 dyn_patient.save_form_progress(
                     registry_code, context_model=newly_created_context)
-
-                try:
-                    create_field_values(registry,
-                                        patient,
-                                        newly_created_context)
-                except Exception as ex:
-                    logger.debug("Error creating field values for new context: %s" % ex)
 
                 xray_recorder.end_subsegment()
                 xray_recorder.end_subsegment()  # End main subsegment


### PR DESCRIPTION
A very simple change to fix the problem.

Makes reporting slower, but will speed up form saving and fix the concurrency issues.

We could also outright remove `FieldValue`s all together, and just retrieve the values from clinical data for `current` reports.

I've elected to preserve them given that any changes would need to preserve the semantics around stringifying the various datatypes, and the current explorer's eventual deprecation.