### PR TITLE
SQL query reductions #1 in patient save

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   unixodbc \
   # Builder
   build-essential \
+  git \
   gzip \
   libpcre3-dev \
   libpq-dev \
@@ -64,6 +65,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   nodejs \
   unixodbc \
   libmagic1 \
+  git \
   && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN mkdir /requirements

--- a/docker/dev/docker-entrypoint.sh
+++ b/docker/dev/docker-entrypoint.sh
@@ -156,6 +156,7 @@ function _runserver() {
 
     _django_migrate
     _django_fixtures
+    mkdir -p /data/python_profiling
 
     info "RUNSERVER_OPTS is ${RUNSERVER_OPTS}"
     set -x

--- a/rdrf/rdrf/db/dynamic_data.py
+++ b/rdrf/rdrf/db/dynamic_data.py
@@ -8,9 +8,10 @@ from rdrf.db.filestorage import create_filestorage
 from rdrf.forms.file_upload import FileUpload, wrap_fs_data_for_form
 from rdrf.models.definition.models import Registry, ClinicalData
 from rdrf.helpers.utils import get_code, models_from_mongo_key, is_delimited_key, mongo_key, is_multisection
-from rdrf.helpers.utils import is_file_cde, is_multiple_file_cde, is_uploaded_file
+from rdrf.helpers.utils import is_file_cde, is_multiple_file_cde, is_uploaded_file, silk_profile
 
 from aws_xray_sdk.core import xray_recorder
+
 
 logger = logging.getLogger(__name__)
 
@@ -775,6 +776,7 @@ class DynamicDataWrapper(object):
         if record is not None:
             self._save_longitudinal_snapshot(registry_code, record, form_name=form_name, form_user=form_user)
 
+    @silk_profile(name="Save Form Progress")
     def save_form_progress(self, registry_code, context_model=None):
         from rdrf.forms.progress.form_progress import FormProgress
         xray_recorder.begin_subsegment("build_objects")

--- a/rdrf/rdrf/forms/dsl/parse_operations.py
+++ b/rdrf/rdrf/forms/dsl/parse_operations.py
@@ -1,3 +1,4 @@
+from functools import lru_cache
 from lark import Lark, Transformer
 from .constants import QUALIFIERS, INVERSE_ACTION_MAP, DSL_DEFINITION, PREDEFINED_VALUES
 from .parse_utils import EnrichedCDE
@@ -143,6 +144,7 @@ class TreeTransformer(Transformer):
         return BooleanOp(input[0].value)
 
 
+@lru_cache
 def parse_dsl(dsl):
     p = Lark(DSL_DEFINITION, parser='lalr', start='start', debug=False)
     return p.parse(dsl)

--- a/rdrf/rdrf/forms/dsl/validator.py
+++ b/rdrf/rdrf/forms/dsl/validator.py
@@ -8,6 +8,8 @@ from .constants import INCLUDE_OPERATORS
 from .parse_utils import CDEHelper, SectionHelper, is_iterable
 from .parse_operations import parse_dsl, transform_tree, Condition, BooleanOp
 
+from rdrf.forms.dsl.parse_utils import prefetch_form_data
+
 logger = logging.getLogger(__name__)
 
 
@@ -235,6 +237,7 @@ class DSLValidator:
     def __init__(self, dsl, form):
         self.dsl = dsl
         self.form = form
+        prefetch_form_data.cache_clear()
         self.cde_helper = CDEHelper(form)
         self.section_helper = SectionHelper(form)
 

--- a/rdrf/rdrf/forms/file_upload.py
+++ b/rdrf/rdrf/forms/file_upload.py
@@ -83,7 +83,7 @@ def wrap_fs_data_for_form(registry, data):
     return wrap(data, None)
 
 
-def wrap_file_cdes(registry_code, section_data, mongo_data, multisection=False, index_map={}):
+def wrap_file_cdes(registry_code, file_cdes, section_data, mongo_data, multisection=False, index_map={}):
     # Wrap file cde data for display in the form
     # I've refactored the code trying to make it as explicit as possible but it
     # would  still be good to refactor later as it is very painful
@@ -121,7 +121,7 @@ def wrap_file_cdes(registry_code, section_data, mongo_data, multisection=False, 
     #               no upload and value False in form to indicate clearing - don't wrap
     #               upload of file : wrap form data
 
-    from rdrf.helpers.utils import is_file_cde, get_code, get_form_section_code
+    from rdrf.helpers.utils import get_code, get_form_section_code
 
     def is_existing_in_mongo(section_index, key, value):
         if mongo_data is None:
@@ -145,7 +145,8 @@ def wrap_file_cdes(registry_code, section_data, mongo_data, multisection=False, 
             # not a delimited mongo key
             return False
 
-        if is_file_cde(cde_code):
+        is_file_cde = cde_code in file_cdes
+        if is_file_cde:
             u = is_upload_file(value)
             fs = is_filestorage_dict(value)
             im = is_existing_in_mongo(section_index, key, value)

--- a/rdrf/rdrf/helpers/utils.py
+++ b/rdrf/rdrf/helpers/utils.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 import datetime
 from functools import total_ordering
 import logging
@@ -17,6 +18,7 @@ from django.utils.html import strip_tags
 
 from .cde_data_types import CDEDataTypes
 from .registry_features import RegistryFeatures
+
 
 logger = logging.getLogger(__name__)
 
@@ -263,24 +265,19 @@ def forms_and_sections_containing_cde(registry_model, cde_model_to_find):
 
 def consent_status_for_patient(registry_code, patient):
     from registry.patients.models import ConsentValue
-    from rdrf.models.definition.models import ConsentSection, ConsentQuestion
 
-    consent_sections = ConsentSection.objects.filter(
-        registry__code=registry_code)
-    answers = {}
-    valid = []
-    for consent_section in consent_sections:
-        if consent_section.applicable_to(patient):
-            questions = ConsentQuestion.objects.filter(section=consent_section)
-            for question in questions:
-                try:
-                    cv = ConsentValue.objects.get(
-                        patient=patient, consent_question=question)
-                    answers[cv.consent_question.code] = cv.answer
-                except ConsentValue.DoesNotExist:
-                    pass
-            valid.append(consent_section.is_valid(answers))
-    return all(valid)
+    values = ConsentValue.objects.filter(
+        patient=patient,
+        consent_question__section__registry__code=registry_code
+    ).select_related("consent_question", "consent_question__section")
+
+    answers = defaultdict(dict)
+    sections = {}
+    for v in values:
+        section = v.consent_question.section
+        sections[section.code] = section
+        answers[section.code][v.consent_question.code] = v.answer
+    return all(sections[section_code].is_valid(section_answers) for section_code, section_answers in answers.items())
 
 
 def get_error_messages(forms):
@@ -841,3 +838,10 @@ def make_full_url(relative_url):
     scheme = 'https' if domain != 'localhost:8000' else 'http'
     augmented = splitted._replace(scheme=scheme, netloc=domain)
     return urlunsplit(augmented)
+
+
+def silk_profile(*args, **kwargs):
+    if settings.PROFILING:
+        from silk.profiling.profiler import silk_profile
+        return silk_profile(*args, **kwargs)
+    return lambda x: x

--- a/rdrf/rdrf/models/definition/models.py
+++ b/rdrf/rdrf/models/definition/models.py
@@ -55,7 +55,9 @@ class SectionManager(models.Manager):
         return self.get(code=code)
 
     def get_by_comma_separated_codes(self, codes):
-        return self.filter(code__in=[s.strip() for s in codes.split(",")])
+        codes = [s.strip() for s in codes.split(",")]
+        sections = {s.code: s for s in self.filter(code__in=codes)}
+        return [section for code in codes if (section := sections.get(code))]
 
 
 class Section(models.Model):

--- a/rdrf/rdrf/settings.py
+++ b/rdrf/rdrf/settings.py
@@ -33,6 +33,7 @@ SECURE_HSTS_INCLUDE_SUBDOMAINS = True
 X_FRAME_OPTIONS = env.get("x_frame_options", 'DENY')
 
 DEBUG = env.get("debug", not PRODUCTION)
+PROFILING = env.get("profiling", False)
 
 SITE_ID = env.get("site_id", 1)
 APPEND_SLASH = env.get("append_slash", True)
@@ -143,9 +144,10 @@ MESSAGE_TAGS = {
 # shows up messages addressed to other users.
 MESSAGE_STORAGE = 'django.contrib.messages.storage.session.SessionStorage'
 
-MIDDLEWARE = (
+MIDDLEWARE = [x for x in (
     'registry.common.middleware.XrayExceptionMiddleware',
     'aws_xray_sdk.ext.django.middleware.XRayMiddleware',
+    'silk.middleware.SilkyMiddleware' if PROFILING else None,
     'useraudit.middleware.RequestToThreadLocalMiddleware',
     'registry.common.middleware.NoCacheMiddleware',
     'csp.middleware.CSPMiddleware',
@@ -163,10 +165,10 @@ MIDDLEWARE = (
     'django_user_agents.middleware.UserAgentMiddleware',
     'simple_history.middleware.HistoryRequestMiddleware',
     'stronghold.middleware.LoginRequiredMiddleware',
-)
+) if x is not None]
 
 
-INSTALLED_APPS = [
+INSTALLED_APPS = [x for x in (
     'rdrf',
     'django.contrib.contenttypes',
     'django.contrib.auth',
@@ -199,8 +201,9 @@ INSTALLED_APPS = [
     'django_js_reverse',
     'stronghold',
     'aws_xray_sdk.ext.django',
-    'django_countries'
-]
+    'django_countries',
+    'silk' if PROFILING else None,
+) if x is not None]
 
 
 # these determine which authentication method to use
@@ -713,3 +716,8 @@ if ENABLE_CROWDIN_IN_CONTEXT_TRANSLATION:
     CSP_IMG_SRC += ["https://cdn.crowdin.com", "https://*.downloads.crowdin.com", "data:"]
     CSP_CONNECT_SRC += ["https://eresearchqut.crowdin.com"]
     CSP_FRAME_SRC += ["https://cdn.crowdin.com", "https://eresearchqut.crowdin.com"]
+
+SILKY_META = True
+SILKY_PYTHON_PROFILER = True
+SILKY_PYTHON_PROFILER_BINARY = True
+SILKY_PYTHON_PROFILER_RESULT_PATH = '/data/python_profiling'

--- a/rdrf/rdrf/templates/rdrf_cdes/form.html
+++ b/rdrf/rdrf/templates/rdrf_cdes/form.html
@@ -1,7 +1,6 @@
 {% extends "rdrf_cdes/base-2-cols.html" %}
 {% load array_item %}
 {% load get_display_name %}
-{% load get_cde_name %}
 {% load get_section_id %}
 {% load is_formset %}
 {% load get_management_form %}
@@ -320,7 +319,7 @@
                                     {% elif fpc.1 == False %}
                                         <img src='{% static 'images/cross.png'%}'>
                                     {% endif %}
-                                    {{fpc.0|get_cde_name|translate}}
+                                    {{fpc.0|translate}}
                                 </li>
                             {% endfor %}
                         </ul>

--- a/rdrf/rdrf/urls.py
+++ b/rdrf/rdrf/urls.py
@@ -113,6 +113,7 @@ proms_patterns = [
 ]
 
 normalpatterns += [
+    re_path(r'^silk/', include('silk.urls', namespace='silk')) if settings.PROFILING else None,
     re_path(r'^actions/?$', ActionExecutorView.as_view(), name='action'),
     re_path(r'^translations/jsi18n/$', JavaScriptCatalog.as_view(), name='javascript-catalog'),
     re_path(r'^useraudit/', include('useraudit.urls',)),

--- a/rdrf/rdrf/views/form_view.py
+++ b/rdrf/rdrf/views/form_view.py
@@ -1,9 +1,15 @@
+from collections import OrderedDict
+from functools import cached_property, reduce
+import json
+import logging
+import operator
+import os
+
 from csp.decorators import csp_update
 from django.shortcuts import render, get_object_or_404
 from django.template.loader import render_to_string
 from django.views.generic.base import View, TemplateView
 from django.template.context_processors import csrf
-from django.core.exceptions import ObjectDoesNotExist
 from django.core.exceptions import PermissionDenied
 from django.contrib import messages
 from django.http import HttpResponse, FileResponse, JsonResponse
@@ -14,18 +20,18 @@ from django.utils.decorators import method_decorator
 from django.utils.safestring import mark_safe
 
 from rdrf.models.definition.models import RegistryForm, Registry, QuestionnaireResponse, ContextFormGroup
-from rdrf.models.definition.models import CDEFile, Section, CommonDataElement
+from rdrf.models.definition.models import CDEFile, CommonDataElement
 from registry.patients.models import Patient, ParentGuardian, PatientSignature
 from rdrf.forms.dynamic.dynamic_forms import create_form_class_for_section
 from rdrf.db.dynamic_data import DynamicDataWrapper
 from rdrf.db.filestorage import virus_checker_result
 from django.http import Http404
 from rdrf.forms.dsl.code_generator import CodeGenerator
+from rdrf.forms.dsl.parse_utils import prefetch_form_data
 from rdrf.forms.file_upload import wrap_fs_data_for_form
 from rdrf.forms.file_upload import wrap_file_cdes
 from rdrf.db import filestorage
-from rdrf.helpers.utils import de_camelcase, location_name, is_multisection, make_index_map
-from rdrf.helpers.utils import parse_iso_date
+from rdrf.helpers.utils import de_camelcase, location_name, make_index_map, parse_iso_date, silk_profile
 from rdrf.views.decorators.patient_decorators import patient_questionnaire_access
 from rdrf.forms.navigation.wizard import NavigationWizard, NavigationFormType
 from rdrf.models.definition.models import RDRFContext
@@ -46,9 +52,6 @@ from registry.patients.models import PatientConsent
 from registry.patients.admin_forms import PatientConsentFileForm, PatientSignatureForm
 from django.utils.translation import ugettext as _
 
-import json
-import os
-from collections import OrderedDict
 from django.conf import settings
 from rdrf.services.rpc.actions import ActionExecutor
 from rdrf.helpers.utils import FormLink, consent_check
@@ -74,7 +77,6 @@ from rdrf.security.mixins import StaffMemberRequiredMixin
 
 from aws_xray_sdk.core import xray_recorder
 
-import logging
 
 logger = logging.getLogger(__name__)
 
@@ -137,6 +139,7 @@ class SectionInfo(object):
 
     def __init__(self,
                  section_code,
+                 file_cdes,
                  patient_wrapper,
                  is_multiple,
                  registry_code,
@@ -147,6 +150,7 @@ class SectionInfo(object):
                  form_class=None,
                  prefix=None):
         self.section_code = section_code
+        self.file_cdes = file_cdes
         self.patient_wrapper = patient_wrapper
         self.is_multiple = is_multiple
         self.registry_code = registry_code
@@ -182,6 +186,7 @@ class SectionInfo(object):
 
         wrapped_data = wrap_file_cdes(
             self.registry_code,
+            self.file_cdes,
             dynamic_data,
             current_data,
             multisection=self.is_multiple)
@@ -511,6 +516,7 @@ class FormView(View):
         # the ids of each cde on the form
         return ",".join(form_class().fields.keys())
 
+    @silk_profile(name='Form View Post')
     def post(self, request, registry_code, form_id, patient_id, context_id=None):
         xray_recorder.begin_subsegment('formview_post')
         xray_recorder.begin_subsegment("auth")
@@ -581,7 +587,7 @@ class FormView(View):
         self.registry_form = form_obj
 
         form_display_name = form_obj.display_name if form_obj.display_name else form_obj.name
-        sections, display_names, ids = self._get_sections(form_obj)
+        dd = DataDefinitions(form_obj)
         form_section = {}
         section_element_map = {}
         total_forms_ids = {}
@@ -592,8 +598,8 @@ class FormView(View):
         # the full ids on form eg { "section23": ["form23^^sec01^^CDEName", ... ] , ...}
         section_field_ids_map = {}
 
-        for section_index, s in enumerate(sections):
-            section_model = Section.objects.get(code=s)
+        for section_model in dd.section_models:
+            s = section_model.code
             form_class = create_form_class_for_section(
                 registry,
                 form_obj,
@@ -616,6 +622,7 @@ class FormView(View):
                     dynamic_data = form.cleaned_data
                     section_info = SectionInfo(
                         s,
+                        dd.file_cde_codes,
                         dyn_patient,
                         False,
                         registry_code,
@@ -625,7 +632,7 @@ class FormView(View):
                     sections_to_save.append(section_info)
                     current_data = dyn_patient.load_dynamic_data(self.registry.code, "cdes")
                     form_data = wrap_file_cdes(
-                        registry_code, dynamic_data, current_data, multisection=False)
+                        registry_code, dd.file_cde_codes, dynamic_data, current_data, multisection=False)
                     form_section[s] = form_class(dynamic_data, initial=form_data)
                 else:
                     all_sections_valid = False
@@ -665,19 +672,22 @@ class FormView(View):
 
                     current_data = dyn_patient.load_dynamic_data(self.registry.code, "cdes")
                     section_dict = {s: dynamic_data}
-                    section_info = SectionInfo(s,
-                                               dyn_patient,
-                                               True,
-                                               registry_code,
-                                               "cdes",
-                                               section_dict,
-                                               index_map,
-                                               form_set_class=form_set_class,
-                                               prefix=prefix)
+                    section_info = SectionInfo(
+                        s,
+                        dd.file_cde_codes,
+                        dyn_patient,
+                        True,
+                        registry_code,
+                        "cdes",
+                        section_dict,
+                        index_map,
+                        form_set_class=form_set_class,
+                        prefix=prefix)
 
                     sections_to_save.append(section_info)
                     form_data = wrap_file_cdes(
                         registry_code,
+                        dd.file_cde_codes,
                         dynamic_data,
                         current_data,
                         multisection=True,
@@ -706,6 +716,8 @@ class FormView(View):
                 form_section[section_info.section_code] = form_instance
 
             xray_recorder.end_subsegment()
+
+            prefetch_form_data.cache_clear()
 
             xray_recorder.begin_subsegment("file_notifications")
             handle_file_notifications(registry, patient, dyn_patient.filestorage)
@@ -800,19 +812,19 @@ class FormView(View):
             'form_display_name': form_display_name,
             'patient_id': patient_id,
             'patient_link': PatientLocator(registry, patient).link,
-            'sections': sections,
+            'sections': dd.sections,
             'patient_info': patient_info_component.html,
             'section_field_ids_map': section_field_ids_map,
-            'section_ids': ids,
+            'section_ids': dd.ids,
             'forms': form_section,
             'my_contexts_url': patient.get_contexts_url(self.registry),
-            'display_names': display_names,
+            'display_names': dd.display_names,
             'section_element_map': section_element_map,
             "total_forms_ids": total_forms_ids,
             "initial_forms_ids": initial_forms_ids,
             "formset_prefixes": formset_prefixes,
             "form_links": self._get_formlinks(request.user, self.rdrf_context),
-            "metadata_json_for_sections": self._get_metadata_json_dict(self.registry_form),
+            "metadata_json_for_sections": self._get_metadata_json_dict(dd),
             "has_form_progress": self.registry_form.has_progress_indicator,
             "location": location_name(self.registry_form, self.rdrf_context),
             "next_form_link": wizard.next_link,
@@ -842,11 +854,12 @@ class FormView(View):
                 progress_percentage = 0
 
             context["form_progress"] = progress_percentage
-            initial_completion_cdes = {cde_model.name: False for cde_model in
-                                       self.registry_form.complete_form_cdes.all()}
-
-            context["form_progress_cdes"] = progress_dict.get(
-                self.registry_form.name + "_form_cdes_status", initial_completion_cdes)
+            progress_cdes = progress_dict.get(self.registry_form.name + "_form_cdes_status")
+            if progress_cdes is None:
+                context["form_progress_cdes"] = {cde_model.name: False for cde_model in self.registry_form.complete_form_cdes.all()}
+            else:
+                cdes = {cde.code: cde.name for cde in self.registry_form.complete_form_cdes.all()}
+                context["form_progress_cdes"] = {cdes.get(code, code): value for code, value in progress_cdes.items()}
 
         context.update(csrf(request))
         self.registry_form = self.get_registry_form(form_id)
@@ -880,21 +893,6 @@ class FormView(View):
 
         xray_recorder.end_subsegment()
         return response
-
-    def _get_sections(self, form):
-        section_parts = form.get_sections()
-        sections = []
-        display_names = {}
-        ids = {}
-        for s in section_parts:
-            try:
-                sec = Section.objects.get(code=s.strip())
-                display_names[s] = sec.display_name
-                ids[s] = sec.id
-                sections.append(s)
-            except ObjectDoesNotExist:
-                logger.error("Section %s does not exist" % s)
-        return sections, display_names, ids
 
     def get_registry_form(self, form_id):
         return RegistryForm.objects.get(id=form_id)
@@ -936,7 +934,9 @@ class FormView(View):
         """
         user = kwargs.get("user", None)
         patient_model = kwargs.get("patient_model", None)
-        sections, display_names, ids = self._get_sections(self.registry_form)
+
+        dd = DataDefinitions(self.registry_form)
+
         form_section = {}
         section_element_map = {}
         total_forms_ids = {}
@@ -955,9 +955,10 @@ class FormView(View):
         allowed_cdes = form_changes.allowed_cdes if changes_since_version else []
         previous_values = form_changes.previous_values if changes_since_version else {}
 
+        sections = dd.sections
         remove_sections = []
-        for s in sections:
-            section_model = Section.objects.get(code=s)
+        for section_model in dd.section_models:
+            s = section_model.code
             form_class = self._get_form_class_for_section(
                 self.registry, self.registry_form, section_model, allowed_cdes, previous_values)
             if not form_class:
@@ -1033,8 +1034,8 @@ class FormView(View):
             'patient_name': self._get_patient_name(),
             'sections': sections,
             'forms': form_section,
-            'display_names': display_names,
-            'section_ids': ids,
+            'display_names': dd.display_names,
+            'section_ids': dd.ids,
             "not_linked": patient_model.is_linked if patient_model else True,
             'section_element_map': section_element_map,
             "total_forms_ids": total_forms_ids,
@@ -1042,7 +1043,7 @@ class FormView(View):
             "initial_forms_ids": initial_forms_ids,
             "formset_prefixes": formset_prefixes,
             "form_links": form_links,
-            "metadata_json_for_sections": self._get_metadata_json_dict(self.registry_form),
+            "metadata_json_for_sections": self._get_metadata_json_dict(dd),
             "has_form_progress": self.registry_form.has_progress_indicator,
             "have_dynamic_data": bool(self.dynamic_data),
             "settings": settings,
@@ -1080,9 +1081,8 @@ class FormView(View):
     def _get_patient_object(self):
         return Patient.objects.get(pk=self.patient_id)
 
-    def _get_metadata_json_dict(self, registry_form):
+    def _get_metadata_json_dict(self, defs):
         """
-        :param registry_form model instance
         :return: a dictionary of section --> metadata json for cdes in the section
         Used by the dynamic formset plugin client side to override behaviour
 
@@ -1090,21 +1090,18 @@ class FormView(View):
         """
         json_dict = {}
         from rdrf.helpers.utils import id_on_page
-        for section in registry_form.get_sections():
+        for section_model in defs.section_models:
             metadata = {}
-            section_model = Section.objects.filter(code=section).first()
-            if section_model:
-                for cde_code in section_model.get_elements():
-                    cde = CommonDataElement.objects.filter(code=cde_code).first()
-                    if cde:
-                        cde_code_on_page = id_on_page(registry_form, section_model, cde)
-                        if cde.datatype.lower() == CDEDataTypes.DATE:
-                            # date widgets are complex
-                            metadata[cde_code_on_page] = {}
-                            metadata[cde_code_on_page]["row_selector"] = cde_code_on_page + "_month"
+            for cde_code in section_model.get_elements():
+                cde = defs.form_cdes[cde_code]
+                cde_code_on_page = id_on_page(defs.registry_form, section_model, cde)
+                if cde.datatype.lower() == CDEDataTypes.DATE:
+                    # date widgets are complex
+                    metadata[cde_code_on_page] = {}
+                    metadata[cde_code_on_page]["row_selector"] = cde_code_on_page + "_month"
 
             if metadata:
-                json_dict[section] = json.dumps(metadata)
+                json_dict[section_model.code] = json.dumps(metadata)
 
         return json_dict
 
@@ -1320,7 +1317,7 @@ class QuestionnaireView(FormView):
 
         questionnaire_form = registry.questionnaire
         self.registry_form = questionnaire_form
-        sections, display_names, ids = self._get_sections(registry.questionnaire)
+        dd = DataDefinitions(registry.questionnaire)
         # section --> dynamic data for questionnaire response object if no errors
         data_map = {}
         # section --> form instances if there are errors and form needs to be redisplayed
@@ -1333,8 +1330,8 @@ class QuestionnaireView(FormView):
         # the full ids on form eg { "section23": ["form23^^sec01^^CDEName", ... ] , ...}
         section_field_ids_map = {}
 
-        for section in sections:
-            section_model = Section.objects.get(code=section)
+        for section_model in dd.section_models:
+            section = section_model.code
             section_elements = section_model.get_elements()
             section_element_map[section] = section_elements
             form_class = create_form_class_for_section(
@@ -1387,16 +1384,11 @@ class QuestionnaireView(FormView):
                 registry_code, "cdes", {
                     "custom_consent_data": custom_consent_helper.custom_consent_data})
 
-            for section in sections:
-                data_map[section]['questionnaire_context'] = self.questionnaire_context
-                if is_multisection(section):
-                    questionnaire_response_wrapper.save_dynamic_data(
-                        registry_code, "cdes", data_map[section], multisection=True,
-                        additional_data={"questionnaire_context": self.questionnaire_context})
-                else:
-                    questionnaire_response_wrapper.save_dynamic_data(
-                        registry_code, "cdes", data_map[section],
-                        additional_data={"questionnaire_context": self.questionnaire_context})
+            for section in dd.section_models:
+                data_map[section.code]['questionnaire_context'] = self.questionnaire_context
+                questionnaire_response_wrapper.save_dynamic_data(
+                    registry_code, "cdes", data_map[section.code], multisection=section.allow_multiple,
+                    additional_data={"questionnaire_context": self.questionnaire_context})
 
             def get_completed_questions(
                     questionnaire_form_model,
@@ -1539,15 +1531,15 @@ class QuestionnaireView(FormView):
                 'form_display_name': registry.questionnaire.name,
                 'patient_id': 'dummy',
                 'patient_name': '',
-                'sections': sections,
+                'sections': dd.sections,
                 'forms': form_section,
-                'display_names': display_names,
+                'display_names': dd.display_names,
                 'section_element_map': section_element_map,
                 'section_field_ids_map': section_field_ids_map,
                 "total_forms_ids": total_forms_ids,
                 "initial_forms_ids": initial_forms_ids,
                 "formset_prefixes": formset_prefixes,
-                "metadata_json_for_sections": self._get_metadata_json_dict(self.registry_form)
+                "metadata_json_for_sections": self._get_metadata_json_dict(dd)
             }
 
             context.update(csrf(request))
@@ -2024,3 +2016,36 @@ class CdeAvailableWidgetsView(View):
     def get(self, request, data_type):
         widgets = [{'name': name, 'value': name} for name in sorted(get_widgets_for_data_type(data_type))]
         return JsonResponse({'widgets': widgets})
+
+
+class DataDefinitions:
+    def __init__(self, registry_form):
+        self.registry_form = registry_form
+
+    @cached_property
+    def section_models(self):
+        return self.registry_form.section_models
+
+    @cached_property
+    def sections(self):
+        return [s.code for s in self.section_models]
+
+    @cached_property
+    def ids(self):
+        return {s.code: s.id for s in self.section_models}
+
+    @cached_property
+    def display_names(self):
+        return {s.code: s.display_name for s in self.section_models}
+
+    @cached_property
+    def form_cde_codes(self):
+        return set(reduce(operator.add, [section.get_elements() for section in self.section_models]))
+
+    @cached_property
+    def form_cdes(self):
+        return {cde.code: cde for cde in CommonDataElement.objects.filter(code__in=self.form_cde_codes)}
+
+    @cached_property
+    def file_cde_codes(self):
+        return set(cde_code for cde_code, cde in self.form_cdes.items() if cde.datatype == CDEDataTypes.FILE)

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -3,3 +3,7 @@ sphinxcontrib-fulltoc
 Werkzeug
 python-Levenshtein
 ipython
+# TODO change this to django-silk when the following issue is released:
+# https://github.com/jazzband/django-silk/issues/522 
+# Currently is fixed, but not released. Can't use silk with multiple DATABASES until fix gets in.
+git+https://github.com/jazzband/django-silk.git#egg=django-silk


### PR DESCRIPTION
This is the first phase as discussed.

I'm using 2 approaches:

1. using a cached function to preload data used and re-used by conditional DSL helper classes

2. creating a `DataDefinitions` class that is used to fetch some data early in the POST the the following code uses the class's `@cached_properties`.

I like the second approach better, but initially I started with the first, so I left it there for now.
In future iterations, we should probably unify the 2 and expand more on it, to include more data definitions properties and make more code using them instead of re-fetching.
I think there are further, relatively easy fixes, but I just ran out of time.
I also looked at some lower benefit changes, but they looked riskier, needed more time to properly understand/fix so I left them out for now.
 