### PR TITLE
[ERE-1668] Fix CDE progress field order

### DIFF
--- a/rdrf/rdrf/forms/progress/form_progress.py
+++ b/rdrf/rdrf/forms/progress/form_progress.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 import logging
 import math
 
@@ -225,7 +226,7 @@ class FormProgressCalculator:
             hidden_cdes = self._get_hidden_cdes(form_model)
             required_cdes = set(required_cdes) - hidden_cdes
 
-        cdes_status = {code: False for code in required_cdes}
+        cdes_status = OrderedDict((cde, False) for _, cde in self._get_progress_cdes())
 
         code_values_dict = {}
         for cde_dict in self._form_section_traversal():

--- a/rdrf/rdrf/views/form_view.py
+++ b/rdrf/rdrf/views/form_view.py
@@ -1060,13 +1060,21 @@ class FormView(View):
 
             form_progress = FormProgress(self.registry_form.registry)
 
-            form_progress_percentage = form_progress.get_form_progress(self.registry_form,
-                                                                       patient_model,
-                                                                       self.rdrf_context)
+            form_progress_percentage = form_progress.get_form_progress(
+                self.registry_form, patient_model, self.rdrf_context)
 
-            form_cdes_status = form_progress.get_form_cdes_status(self.registry_form,
-                                                                  patient_model,
-                                                                  self.rdrf_context)
+            form_cdes_status_by_code = form_progress.get_form_cdes_status(
+                self.registry_form, patient_model, self.rdrf_context)
+
+            ordered_cde_codes = (cde
+                                 for section in sections
+                                 for cde in section_element_map[section]
+                                 if cde in form_cdes_status_by_code)
+
+            def cde_name(cde_code):
+                return dd.form_cdes[cde_code].name
+
+            form_cdes_status = OrderedDict((cde_name(cde), form_cdes_status_by_code[cde]) for cde in ordered_cde_codes)
 
             context["form_progress"] = form_progress_percentage
             context["form_progress_cdes"] = form_cdes_status


### PR DESCRIPTION
Makes the progress CDEs appear in the same order as the CDEs on the page.