### PR TITLE
Install django-silk from pypi instead of GitHub

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -3,7 +3,4 @@ sphinxcontrib-fulltoc
 Werkzeug
 python-Levenshtein
 ipython
-# TODO change this to django-silk when the following issue is released:
-# https://github.com/jazzband/django-silk/issues/522 
-# Currently is fixed, but not released. Can't use silk with multiple DATABASES until fix gets in.
-git+https://github.com/jazzband/django-silk.git#egg=django-silk
+django-silk


### PR DESCRIPTION
There is a new version of django-silk 4.3.0, so we can install from pypi now instead of installing from GitHub.

Reference: https://github.com/jazzband/django-silk/issues/551#issuecomment-1060915536
