### PR TITLE
[ERE-1704] Use native language labels

### DIFF
--- a/rdrf/rdrf/templates/rdrf_cdes/navbar_links.html
+++ b/rdrf/rdrf/templates/rdrf_cdes/navbar_links.html
@@ -2,12 +2,13 @@
 {% load translate %}
 {% load project_title %}
 {% load project_title_link %}
+{% load get_language_settings %}
 
 {% include "localisation/language_picker_form.html" %}
 <div class="collapse navbar-collapse justify-content-end" id="navbar-collapsing-links">
     <ul class="navbar-nav navbar-right">
       <li class="nav-item"><a class="nav-link d-md-none" href="{% project_title_link %}">{% project_title %}</a></li>
-        {% get_available_languages as LANGUAGES %}
+        {% get_language_settings as LANGUAGES %}
         {% get_current_language as CURRENT_LANGUAGE %}
         {% if LANGUAGES|length > 1 %}
             <li class="nav-item dropdown">

--- a/rdrf/rdrf/templatetags/get_language_settings.py
+++ b/rdrf/rdrf/templatetags/get_language_settings.py
@@ -1,0 +1,8 @@
+from django import template
+from django.conf import settings
+register = template.Library()
+
+
+@register.simple_tag
+def get_language_settings():
+    return settings.LANGUAGES


### PR DESCRIPTION
Ordinarily we would use [get_language_info](https://docs.djangoproject.com/en/2.2/topics/i18n/translation/#django.utils.translation.get_language_info)

But it doesn't support using custom languages: https://github.com/django/django/blob/7119f40c9881666b6f9b5cf7df09ee1d21cc8344/django/utils/translation/__init__.py#L284 which we need for the `pseudo` language

We could update the `django.conf.locale` dict in `settings.py`, but that is a bit hacky and I haven't seen it recommended anywhere official: https://stackoverflow.com/a/20265032