### PR TITLE
ERE-1789: fix context race condition

### DIFF
--- a/rdrf/rdrf/db/contexts_api.py
+++ b/rdrf/rdrf/db/contexts_api.py
@@ -76,7 +76,7 @@ class RDRFContextManager:
                     # create_args above don't have a DB level unique constraint, so multiple objects
                     # might get created by parallel execution. See: https://bit.ly/3MSchTq
                     # Handling this corner case by always keeping the first context
-                    contexts = list(RDRFContext.objects.filter(**create_args))
+                    contexts = list(RDRFContext.objects.filter(**create_args).order_by('pk'))
                     fixed_context, created = contexts[0], True
                     for redundant_context in contexts[1:]:
                         redundant_context.delete()


### PR DESCRIPTION
I think this race condition might occur when a new Fixed Context Form Group is added and then multiple  requests are made to display the patient listing page at the same time.

Reproduced it locally, by adding a `time.sleep` right after the `RDRFContext.objects.get_or_create`.

Since we can't add a unique constraint on those fields as you noticed the approach in this PR might be the simplest thing that would work.
The alternative would be to re-model the database to make the unique constraint possible, but that would involve many code changes, migrations etc.
