### PR TITLE
[ERE-1795] Custom GraphQL Error Handling

### DIFF
--- a/rdrf/rdrf/urls.py
+++ b/rdrf/rdrf/urls.py
@@ -8,8 +8,6 @@ from django.utils.translation import ugettext as _
 
 from django_js_reverse.views import urls_js
 
-from graphene_django.views import GraphQLView
-
 from two_factor import views as twv
 
 from rdrf.auth.forms import RDRFPasswordResetForm, RDRFSetPasswordForm
@@ -41,6 +39,7 @@ from rdrf.views.session_refresh_view import session_refresh
 from rdrf.views.actions import ActionExecutorView
 import logging
 
+from report.TrrfGraphQLView import TrrfGraphQLView
 from report.schema import create_dynamic_schema
 
 logger = logging.getLogger(__name__)
@@ -61,7 +60,7 @@ if settings.DEBUG is True:
         re_path(r'^test500', handler500, name='test 500'),
         re_path(r'^testAppError', handler_application_error, name='test application error'),
         re_path(r'^raise', handler_exceptions, name='test exception'),
-        path('graphql', lambda request: GraphQLView.as_view(schema=create_dynamic_schema(), graphiql=True)(request))
+        path('graphql', lambda request: TrrfGraphQLView.as_view(schema=create_dynamic_schema(), graphiql=True)(request))
     ]
 
 

--- a/rdrf/report/TrrfGraphQLView.py
+++ b/rdrf/report/TrrfGraphQLView.py
@@ -1,0 +1,25 @@
+import logging
+
+from graphene_django.views import GraphQLView
+from graphql import GraphQLError
+from django.utils.translation import ugettext_lazy as _
+
+logger = logging.getLogger(__name__)
+
+
+class PublicGraphQLError(GraphQLError):
+    pass
+
+
+class TrrfGraphQLView(GraphQLView):
+
+    @staticmethod
+    def format_error(error):
+        super_class = super(TrrfGraphQLView, TrrfGraphQLView)
+
+        if isinstance(error.original_error, PublicGraphQLError):
+            return super_class.format_error(error)
+        else:
+            # Generify the error
+            logger.error(error)
+            return super_class.format_error(GraphQLError(message=_('An unexpected error has occurred.'), path=error.path))


### PR DESCRIPTION
* Generify unexpected errors encountered when executing a GraphQL query to minimise the risk of exposing sensitive application data.
* Provide a way to raise a GraphQL error where the details won't be generified, if we actually want the end user to see the error details (for future api release) via the PublicGraphQLError class.