### PR TITLE
Remove extra Ajax call on patients listings page.

### DIFF
--- a/rdrf/rdrf/templates/rdrf_cdes/patients_listing.html
+++ b/rdrf/rdrf/templates/rdrf_cdes/patients_listing.html
@@ -118,6 +118,7 @@
             var dataTablesConfig = {
                 "processing": true,
                 "serverSide": true,
+                "deferLoading": 0,
                 "bAutoWidth": false,
                 "fnDrawCallback": function (oSettings) {
                     wireUpFormsButtons();
@@ -183,7 +184,6 @@
             });
 
             $("#registry_options").trigger("change");
-
         });
     </script>
 {% endblock %}


### PR DESCRIPTION
The DataTable on the patients listing page executes a POST Ajax
query twice on initialisation.
Removes the extra Ajax request.