### PR TITLE
[ERE-1809] Working Groups are missing from filtered CSV reports

### DIFF
--- a/rdrf/report/TrrfGraphQLView.py
+++ b/rdrf/report/TrrfGraphQLView.py
@@ -17,7 +17,7 @@ class TrrfGraphQLView(GraphQLView):
     def format_error(error):
         super_class = super(TrrfGraphQLView, TrrfGraphQLView)
 
-        if isinstance(error.original_error, PublicGraphQLError):
+        if hasattr(error, 'original_error') and isinstance(error.original_error, PublicGraphQLError):
             return super_class.format_error(error)
         else:
             # Generify the error

--- a/rdrf/report/schema.py
+++ b/rdrf/report/schema.py
@@ -5,7 +5,7 @@ from importlib import import_module
 
 import graphene
 from django.conf import settings
-from django.db.models import Count, Max
+from django.db.models import Count, Max, Q
 from graphene_django import DjangoObjectType
 
 from rdrf.forms.dsl.parse_utils import prefetch_form_data
@@ -377,7 +377,9 @@ def list_patients_query(user,
         .prefetch_related('registered_clinicians')
 
     if working_group_ids:
-        patient_query = patient_query.filter(working_groups__id__in=working_group_ids)
+        # Double negative intended here to ensure the working_groups that don't match the filter aren't excluded from the result set
+        # We only want to exclude the *patients* that aren't in the working groups, not the working groups themselves
+        patient_query = patient_query.exclude(~Q(working_groups__id__in=working_group_ids))
 
     if consent_question_codes:
         for code in consent_question_codes:


### PR DESCRIPTION
 Fix bug where working groups is unintentionally filtered when calculating the max_working_group_count across the matching patient dataset.