### PR TITLE
[ERE-1814] Patient Facets

### DIFF
--- a/rdrf/rdrf/patients/patient_columns.py
+++ b/rdrf/rdrf/patients/patient_columns.py
@@ -201,6 +201,8 @@ class ColumnDateLastUpdated(Column):
         return date_format(val) if val is not None else ""
 
 
+# ERE-1845 - For backwards-compatibility support only
+# Delete me after patient_list metadata_json has been reconfigured to new required format
 class ColumnLivingStatus(Column):
     field = "living_status"
     sort_fields = ["living_status"]

--- a/rdrf/rdrf/patients/query_data.py
+++ b/rdrf/rdrf/patients/query_data.py
@@ -1,0 +1,22 @@
+from gql_query_builder import GqlQuery
+
+from report.schema import create_dynamic_schema
+
+
+class PatientQueryData:
+    def __init__(self, registry):
+        self.registry = registry
+
+    def _get_facet_query(self):
+        fields_facets = ['field', GqlQuery().fields(['label', 'value', 'total']).query('categories').generate()]
+        query_facets = GqlQuery().fields(fields_facets).query('facets').generate()
+        return GqlQuery().fields([query_facets]).query('allPatients', input={'registryCode': f'"{self.registry.code}"'}).operation().generate()
+
+    def get_facet_values(self, request, facet_keys):
+        schema = create_dynamic_schema()
+
+        result = schema.execute(self._get_facet_query(), context_value=request)
+
+        facets = result.data.get('allPatients', {}).get('facets')
+
+        return [facet for facet in facets if facet.get('field') in facet_keys]

--- a/rdrf/rdrf/templates/rdrf_cdes/patients_listing.html
+++ b/rdrf/rdrf/templates/rdrf_cdes/patients_listing.html
@@ -90,16 +90,6 @@
                 return filters;
             }
 
-            function updateFacets(facets) {
-                for (const key in facets) {
-                    const options = facets[key];
-                    for (const option of options) {
-                        const $option = $(`#option-${key}-${option.value}`);
-                        $option.find('[data-filter-item="count"]').text(option.total);
-                    }
-                }
-            }
-
             var load_contexts_list;
             var context_list;
             var dataTablesConfig = {
@@ -137,9 +127,7 @@
                     });
                 load_contexts_list = function () {
                     if (context_list) {
-                        context_list.ajax.reload(function(json) {
-                            updateFacets(json.facets);
-                        });
+                        context_list.ajax.reload();
                     }
                 }
             {% else %}
@@ -177,7 +165,7 @@
 
       <div class="row">
         {% if facets %}
-        <div class="col-lg-3 col-xxl-2">
+        <div class="col-lg-3 col-xxl-2 small">
           <div class="card">
             <h5 class="card-header text-white bg-primary">Filters</h5>
             <ul class="list-group list-group-flush trrf-filters">
@@ -185,18 +173,19 @@
                 <li class="list-group-item">
                   <h6>{{ facet_config|lookup:'label' }}</h6>
                   <ul class="list-group list-group-flush" id="filter-{{ key }}">
-                  {% for option in facet_config|lookup:'options' %}
-                    {% with label=option|lookup:'label' value=option|lookup:'value' count=option|lookup:'count' %}
-                      <li class="list-group-item pt-1 pb-0 border-0" id="option-{{ key }}-{{ value }}">
+                  {% for category in facet_config|lookup:'categories' %}
+                    {% with label=category|lookup:'label' value=category|lookup:'value' total=category|lookup:'total' %}
+                      <li class="list-group-item pt-1 pb-0 border-0 form-check" id="option-{{ key }}-{{ value }}">
                         <input class="form-check-input" type="checkbox" name="filter_{{ key }}" value="{{ value }}" id="filter-{{ key }}-{{ value }}"
-                          {% if value == facet_config|lookup:'default' %}
+                          {% if value and value == facet_config|lookup:'default' %}
                                 checked="checked"
                           {% endif %}
                         >
-                        <label class="form-check-label" for="filter-{{ key }}-{{ value }}">
+                        <label class="form-check-label d-inline" for="filter-{{ key }}-{{ value }}">
                           {{ label }}
                         </label>
-                        <span data-filter-item="count" class="badge bg-primary rounded-pill pull-right">{{ count }}</span>
+                        <span data-filter-item="total" class="badge bg-primary rounded-pill pull-right">{{ total }}</span>
+
                       </li>
                     {% endwith %}
                   {% endfor %}

--- a/rdrf/rdrf/testing/unit/patient_query_data.py
+++ b/rdrf/rdrf/testing/unit/patient_query_data.py
@@ -1,0 +1,42 @@
+import re
+
+from rdrf.models.definition.models import Registry
+from rdrf.patients.query_data import PatientQueryData
+from rdrf.testing.unit.tests import RDRFTestCase
+from registry.groups.models import CustomUser
+
+
+class PatientQueryDataTest(RDRFTestCase):
+
+    def _request(self):
+        class TestContext:
+            user = CustomUser.objects.get(username='admin')
+        return TestContext()
+
+    def _query_syntax(self, query_string):
+        return re.sub(r'\s+', ' ', query_string.strip())
+
+    def test_facet_query(self):
+        query_data = PatientQueryData(Registry.objects.get(code='fh'))
+
+        expected_facet_query = '''
+            query {
+                allPatients(registryCode: "fh") {
+                    facets {
+                        field
+                        categories {
+                            label
+                            value
+                            total
+                        }
+                    }
+                }
+            }
+        '''
+
+        self.assertEqual(self._query_syntax(expected_facet_query), query_data._get_facet_query())
+
+    def test_get_facets(self):
+        query_data = PatientQueryData(Registry.objects.get(code='fh'))
+        facets = query_data.get_facet_values(self._request(), ['living_status'])
+        self.assertEqual(['living_status'], [facet.get('field') for facet in facets])

--- a/rdrf/report/tests/schema_tests.py
+++ b/rdrf/report/tests/schema_tests.py
@@ -9,7 +9,7 @@ from rdrf.models.definition.models import Registry, ClinicalData, ContextFormGro
     CommonDataElement, ConsentQuestion, ConsentSection, CDEPermittedValueGroup, CDEPermittedValue
 from registry.groups import GROUPS as RDRF_GROUPS
 from registry.groups.models import CustomUser, WorkingGroup
-from registry.patients.models import Patient, AddressType, ConsentValue, ParentGuardian
+from registry.patients.models import Patient, AddressType, ConsentValue
 from report.schema import create_dynamic_schema
 
 
@@ -45,15 +45,17 @@ class SchemaTest(TestCase):
         client = Client(create_dynamic_schema())
         query = """
         {
-            dataSummary(registryCode: "test") {
-                maxAddressCount
+            allPatients (registryCode: "test") {
+                dataSummary {
+                    maxAddressCount
+                }
             }
         }
         """
 
         # No addresses
         result = client.execute(query, context_value=self.query_context)
-        self.assertEqual({"data": {"dataSummary": {"maxAddressCount": 0}}}, result)
+        self.assertEqual({"data": {"allPatients": {"dataSummary": {"maxAddressCount": 0}}}}, result)
 
         # Patients with varying number of addresses across different registries
         p1.patientaddress_set.create(address_type=type_home).save()
@@ -64,7 +66,7 @@ class SchemaTest(TestCase):
         p3.patientaddress_set.create(address_type=type_secondary).save()
 
         result = client.execute(query, context_value=self.query_context)
-        self.assertEqual({"data": {"dataSummary": {"maxAddressCount": 2}}}, result)
+        self.assertEqual({"data": {"allPatients": {"dataSummary": {"maxAddressCount": 2}}}}, result)
 
     def test_query_data_summary_max_working_group_count(self):
         create_patient = lambda: Patient.objects.create(consent=True, date_of_birth=datetime(1970, 1, 1))
@@ -88,15 +90,17 @@ class SchemaTest(TestCase):
         client = Client(create_dynamic_schema())
         query = """
         {
-            dataSummary(registryCode: "test") {
-                maxWorkingGroupCount
+            allPatients(registryCode: "test") {
+                dataSummary {
+                    maxWorkingGroupCount
+                }
             }
         }
         """
 
         # No working groups assigned to patients yet
         result = client.execute(query, context_value=self.query_context)
-        self.assertEqual({"data": {"dataSummary": {"maxWorkingGroupCount": 0}}}, result)
+        self.assertEqual({"data": {"allPatients": {"dataSummary": {"maxWorkingGroupCount": 0}}}}, result)
 
         # Patients with varying number of working groups across different registries
         p1.working_groups.set([wg1])
@@ -105,7 +109,7 @@ class SchemaTest(TestCase):
         p4.working_groups.set([wg1, wg2, wg3])
 
         result = client.execute(query, context_value=self.query_context)
-        self.assertEqual({"data": {"dataSummary": {"maxWorkingGroupCount": 3}}}, result)
+        self.assertEqual({"data": {"allPatients": {"dataSummary": {"maxWorkingGroupCount": 3}}}}, result)
 
     def test_query_data_summary_max_clinician_count(self):
         create_patient = lambda: Patient.objects.create(consent=True, date_of_birth=datetime(1970, 1, 1))
@@ -134,15 +138,17 @@ class SchemaTest(TestCase):
         client = Client(create_dynamic_schema())
         query = """
         {
-            dataSummary(registryCode: "test") {
-                maxClinicianCount
+            allPatients(registryCode: "test") {
+                dataSummary {
+                    maxClinicianCount
+                }
             }
         }
         """
 
         # No clinicians assigned to patients yet
         result = client.execute(query, context_value=self.query_context)
-        self.assertEqual({"data": {"dataSummary": {"maxClinicianCount": 0}}}, result)
+        self.assertEqual({"data": {"allPatients": {"dataSummary": {"maxClinicianCount": 0}}}}, result)
 
         # Patients with varying number of addresses across different registries
         p1.registered_clinicians.set([c1, c3])
@@ -150,7 +156,7 @@ class SchemaTest(TestCase):
         p3.registered_clinicians.set([c1, c2, c3, c5, c6])
 
         result = client.execute(query, context_value=self.query_context)
-        self.assertEqual({"data": {"dataSummary": {"maxClinicianCount": 4}}}, result)
+        self.assertEqual({"data": {"allPatients": {"dataSummary": {"maxClinicianCount": 4}}}}, result)
 
     def test_query_data_summary_max_parent_guardian_count(self):
         create_patient = lambda: Patient.objects.create(consent=True, date_of_birth=datetime(1970, 1, 1))
@@ -166,15 +172,17 @@ class SchemaTest(TestCase):
         client = Client(create_dynamic_schema())
         query = """
         {
-            dataSummary(registryCode: "test") {
-                maxParentGuardianCount
+            allPatients(registryCode: "test") {
+                dataSummary {
+                    maxParentGuardianCount
+                }
             }
         }
         """
 
         # No parent guardians
         result = client.execute(query, context_value=self.query_context)
-        self.assertEqual({"data": {"dataSummary": {"maxParentGuardianCount": 0}}}, result)
+        self.assertEqual({"data": {"allPatients": {"dataSummary": {"maxParentGuardianCount": 0}}}}, result)
 
         # Patients with varying number of guardians across registries
         p1.parentguardian_set.create()
@@ -185,18 +193,20 @@ class SchemaTest(TestCase):
         p3.parentguardian_set.create()
 
         result = client.execute(query, context_value=self.query_context)
-        self.assertEqual({"data": {"dataSummary": {"maxParentGuardianCount": 2}}}, result)
+        self.assertEqual({"data": {"allPatients": {"dataSummary": {"maxParentGuardianCount": 2}}}}, result)
 
         query = """
         {
-            dataSummary(registryCode: "another") {
-                maxParentGuardianCount
+            allPatients(registryCode: "another") {
+                dataSummary {
+                    maxParentGuardianCount
+                }
             }
         }
         """
 
         result = client.execute(query, context_value=self.query_context)
-        self.assertEqual({"data": {"dataSummary": {"maxParentGuardianCount": 3}}}, result)
+        self.assertEqual({"data": {"allPatients": {"dataSummary": {"maxParentGuardianCount": 3}}}}, result)
 
     def test_query_sex(self):
         patients = [
@@ -212,25 +222,29 @@ class SchemaTest(TestCase):
 
         result = client.execute("""
         {
-          patients(registryCode: "test") {
-            sex
-          }
+            allPatients(registryCode: "test") {
+                patients {
+                    sex
+                }
+            }
         }
         """, context_value=self.query_context)
 
         self.assertEqual({
             "data": {
-                "patients": [
-                    {
-                        "sex": "Male"
-                    },
-                    {
-                        "sex": "Female"
-                    },
-                    {
-                        "sex": "Indeterminate"
-                    }
-                ]
+                "allPatients": {
+                    "patients": [
+                        {
+                            "sex": "Male"
+                        },
+                        {
+                            "sex": "Female"
+                        },
+                        {
+                            "sex": "Indeterminate"
+                        }
+                    ]
+                }
             }
         }, result)
 
@@ -258,54 +272,66 @@ class SchemaTest(TestCase):
         # No consent filters
         result = client.execute("""
         {
-            patients(registryCode: "test") {
-                id
+            allPatients(registryCode: "test") {
+                patients {
+                    id
+                }
             }
         }
         """, context_value=self.query_context)
 
         self.assertEqual({
             "data": {
-                "patients": [
-                    {'id': '1'},
-                    {'id': '2'},
-                    {'id': '3'}
-                ]
+                "allPatients": {
+                    "patients": [
+                        {'id': '1'},
+                        {'id': '2'},
+                        {'id': '3'}
+                    ]
+                }
             }
         }, result)
 
         # 1 consent filter
         result = client.execute("""
         {
-            patients(registryCode: "test", consentQuestionCodes: ["consent1"]) {
-                id
+            allPatients(registryCode: "test", consentQuestionCodes: ["consent1"]) {
+                patients {
+                    id
+                }
             }
         }
         """, context_value=self.query_context)
 
         self.assertEqual({
             "data": {
-                "patients": [
-                    {'id': '1'},
-                    {'id': '2'}
-                ]
+                "allPatients": {
+                    "patients": [
+                        {'id': '1'},
+                        {'id': '2'}
+                    ]
+                }
             }
         }, result)
 
         # Multiple consent filters
         result = client.execute("""
         {
-            patients(registryCode: "test", consentQuestionCodes: ["consent1", "consent2"]) {
-                id
+            allPatients(registryCode: "test", consentQuestionCodes: ["consent1", "consent2"]) {
+                patients {
+                    id
+                }
             }
         }
         """, context_value=self.query_context)
 
         self.assertEqual({
             "data": {
-                "patients": [
-                    {'id': '2'}
-                ]
+                "allPatients": {
+                    "patients": [
+                        {'id': '2'}
+                    ]
+                }
             }
         }, result)
 
@@ -496,62 +522,68 @@ class SchemaTest(TestCase):
         # Fixed context
         result = client.execute("""
         {
-          patients(registryCode: "test") {
-            clinicalData {
-              clinicalVisit {
-                firstVisit {
-                  inBed {
-                    lieFlat
-                    needHelp
-                  }
+            allPatients(registryCode: "test") {
+                patients {
+                    clinicalData {
+                        clinicalVisit {
+                            firstVisit {
+                                inBed {
+                                    lieFlat
+                                    needHelp
+                                }
+                            }
+                            myBreathing {
+                                breathing {
+                                  breathAssist
+                                }
+                            }
+                        }
+                    }
                 }
-                myBreathing {
-                  breathing {
-                    breathAssist
-                  }
-                }
-              }
             }
-          }
         }
         """, context_value=self.query_context)
 
         self.assertEqual({
             "data": {
-                "patients": [
-                    {
-                        "clinicalData": {
-                            "clinicalVisit": {
-                                "firstVisit": {
-                                    "inBed": {
-                                        "lieFlat": "5",
-                                        "needHelp": ""
-                                    }
-                                },
-                                "myBreathing": {
-                                    "breathing": {
-                                        "breathAssist": "oxygen"
+                "allPatients": {
+                    "patients": [
+                        {
+                            "clinicalData": {
+                                "clinicalVisit": {
+                                    "firstVisit": {
+                                        "inBed": {
+                                            "lieFlat": "5",
+                                            "needHelp": ""
+                                        }
+                                    },
+                                    "myBreathing": {
+                                        "breathing": {
+                                            "breathAssist": "oxygen"
+                                        }
                                     }
                                 }
                             }
                         }
-                    }
-                ]
+                    ]
+                }
             }
         }, result)
 
         # Longitudinal context
         result = client.execute("""
         {
-          patients(registryCode: "test") {
-            clinicalData {
-              symptoms {
-                recentSymptoms {
-                  data {
-                    symptoms {
-                      completedDate
-                      fatigue
-                      pain
+          allPatients(registryCode: "test") {
+            patients {
+              clinicalData {
+                symptoms {
+                  recentSymptoms {
+                    data {
+                      symptoms {
+                        completedDate
+                        fatigue
+                        pain
+                      }
                     }
                   }
                 }
@@ -563,47 +595,51 @@ class SchemaTest(TestCase):
 
         self.assertEqual({
             "data": {
-                "patients": [
-                    {
-                        "clinicalData": {
-                            "symptoms": {
-                                "recentSymptoms": [
-                                    {
-                                        "data": {
-                                            "symptoms": {"completedDate": "2022-02-07", "fatigue": "4", "pain": "1"}
+                "allPatients": {
+                    "patients": [
+                        {
+                            "clinicalData": {
+                                "symptoms": {
+                                    "recentSymptoms": [
+                                        {
+                                            "data": {
+                                                "symptoms": {"completedDate": "2022-02-07", "fatigue": "4", "pain": "1"}
+                                            }
+                                        },
+                                        {
+                                            "data": {
+                                                "symptoms": {"completedDate": "2022-02-08", "fatigue": "3", "pain": "2"}
+                                            }
                                         }
-                                    },
-                                    {
-                                        "data": {
-                                            "symptoms": {"completedDate": "2022-02-08", "fatigue": "3", "pain": "2"}
-                                        }
-                                    }
-                                ]
+                                    ]
+                                }
                             }
                         }
-                    }
-                ]
+                    ]
+                }
             }
         }, result)
 
         # Mixed fixed and longitudinal context
         result = client.execute("""
         {
-          patients(registryCode: "test") {
-            clinicalData {
-              clinicalVisit {
-                firstVisit {
-                  inBed {
-                    lieFlat
+          allPatients(registryCode: "test") {
+            patients {
+              clinicalData {
+                clinicalVisit {
+                  firstVisit {
+                    inBed {
+                      lieFlat
+                    }
                   }
                 }
-              }
-              symptoms {
-                recentSymptoms {
-                  data {
-                    symptoms {
-                      completedDate
-                      fatigue
+                symptoms {
+                  recentSymptoms {
+                    data {
+                      symptoms {
+                        completedDate
+                        fatigue
+                      }
                     }
                   }
                 }
@@ -615,47 +651,51 @@ class SchemaTest(TestCase):
 
         self.assertEqual({
             "data": {
-                "patients": [
-                    {
-                        "clinicalData": {
-                            "clinicalVisit": {
-                                "firstVisit": {
-                                    "inBed": {
-                                        "lieFlat": "5",
-                                    }
-                                },
-                            },
-                            "symptoms": {
-                                "recentSymptoms": [
-                                    {
-                                        "data": {
-                                            "symptoms": {"completedDate": "2022-02-07", "fatigue": "4"}
+                "allPatients": {
+                    "patients": [
+                        {
+                            "clinicalData": {
+                                "clinicalVisit": {
+                                    "firstVisit": {
+                                        "inBed": {
+                                            "lieFlat": "5",
                                         }
                                     },
-                                    {
-                                        "data": {
-                                            "symptoms": {"completedDate": "2022-02-08", "fatigue": "3"}
+                                },
+                                "symptoms": {
+                                    "recentSymptoms": [
+                                        {
+                                            "data": {
+                                                "symptoms": {"completedDate": "2022-02-07", "fatigue": "4"}
+                                            }
+                                        },
+                                        {
+                                            "data": {
+                                                "symptoms": {"completedDate": "2022-02-08", "fatigue": "3"}
+                                            }
                                         }
-                                    }
-                                ]
+                                    ]
+                                }
                             }
                         }
-                    }
-                ]
+                    ]
+                }
             }
         }, result)
 
         # Multisection & Multi value
         result = client.execute("""
         {
-          patients(registryCode: "test") {
-            clinicalData {
-              sleepTracking {
-                sleep {
-                  data {
-                    sleepDiary {
-                      timeToBed
-                      timesAwoke
+          allPatients(registryCode: "test") {
+            patients {
+              clinicalData {
+                sleepTracking {
+                  sleep {
+                    data {
+                      sleepDiary {
+                        timeToBed
+                        timesAwoke
+                      }
                     }
                   }
                 }
@@ -667,24 +707,26 @@ class SchemaTest(TestCase):
 
         self.assertEqual({
             "data": {
-                "patients": [
-                    {
-                        "clinicalData": {
-                            "sleepTracking": {
-                                "sleep": [
-                                    {
-                                        "data": {
-                                            "sleepDiary": [
-                                                {"timeToBed": "9:55pm", "timesAwoke": ["1:00am", "3:00am"]},
-                                                {"timeToBed": "8:45pm", "timesAwoke": ["11:45pm", "5:30am"]}
-                                            ]
+                "allPatients": {
+                    "patients": [
+                        {
+                            "clinicalData": {
+                                "sleepTracking": {
+                                    "sleep": [
+                                        {
+                                            "data": {
+                                                "sleepDiary": [
+                                                    {"timeToBed": "9:55pm", "timesAwoke": ["1:00am", "3:00am"]},
+                                                    {"timeToBed": "8:45pm", "timesAwoke": ["11:45pm", "5:30am"]}
+                                                ]
+                                            }
                                         }
-                                    }
-                                ]
+                                    ]
+                                }
                             }
                         }
-                    }
-                ]
+                    ]
+                }
             }
         }, result)
 
@@ -735,9 +777,11 @@ class SchemaTest(TestCase):
         client = Client(create_dynamic_schema())
         query = """
                {
-                 patients(registryCode: "test") {
-                   clinicalData {
-                     CFG1 { F1 { S1 { single multi singlePvg multiPvg } } }
+                 allPatients(registryCode: "test") {
+                   patients {
+                     clinicalData {
+                       CFG1 { F1 { S1 { single multi singlePvg multiPvg } } }
+                     }
                    }
                  }
                }
@@ -752,22 +796,24 @@ class SchemaTest(TestCase):
         result = client.execute(query, context_value=self.query_context)
         expected = {
             "data": {
-                "patients": [
-                    {
-                        "clinicalData": {
-                            "CFG1": {
-                                "F1": {
-                                    "S1": {
-                                        'single': 'Abc',
-                                        'multi': ['Abc'],
-                                        'singlePvg': 'Low',
-                                        'multiPvg': ['Low', 'Medium']
+                "allPatients": {
+                    "patients": [
+                        {
+                            "clinicalData": {
+                                "CFG1": {
+                                    "F1": {
+                                        "S1": {
+                                            'single': 'Abc',
+                                            'multi': ['Abc'],
+                                            'singlePvg': 'Low',
+                                            'multiPvg': ['Low', 'Medium']
+                                        }
                                     }
                                 }
                             }
                         }
-                    }
-                ]
+                    ]
+                }
             }
         }
 
@@ -782,23 +828,53 @@ class SchemaTest(TestCase):
         result = client.execute(query, context_value=self.query_context)
         expected = {
             "data": {
-                "patients": [
-                    {
-                        "clinicalData": {
-                            "CFG1": {
-                                "F1": {
-                                    "S1": {
-                                        'single': 'Abc',
-                                        'multi': ['Abc'],
-                                        'singlePvg': 'Low',
-                                        'multiPvg': ['Medium']
+                "allPatients": {
+                    "patients": [
+                        {
+                            "clinicalData": {
+                                "CFG1": {
+                                    "F1": {
+                                        "S1": {
+                                            'single': 'Abc',
+                                            'multi': ['Abc'],
+                                            'singlePvg': 'Low',
+                                            'multiPvg': ['Medium']
+                                        }
                                     }
                                 }
                             }
                         }
-                    }
-                ]
+                    ]
+                }
             }
         }
 
         self.assertEqual(expected, result)
+
+    def test_dynamic_schema_is_dynamic(self):
+        # Registry Definition
+        CommonDataElement.objects.create(code='CDE1', abbreviated_name='CDE-1', name="CDE-1")
+        CommonDataElement.objects.create(code='CDE2', abbreviated_name='CDE-2', name="CDE-2")
+        sec1 = Section.objects.create(code='SEC1', elements='CDE1', abbreviated_name='SEC1', display_name='SEC1')
+        form1 = RegistryForm.objects.create(name='FORM1', sections='SEC1', registry=self.registry, abbreviated_name='FORM1')
+        cfg1 = ContextFormGroup.objects.create(code='CFG1', registry=self.registry, name='CFG1', context_type="F", abbreviated_name="CFG1", sort_order=1)
+        cfg1.items.create(registry_form=form1)
+
+        # Check schema fields
+        schema = create_dynamic_schema()
+        schema_section_type = schema.get_type('DynamicSection_CFG1_FORM1_SEC1')
+        fields = (list(schema_section_type.fields.keys()))
+
+        self.assertEqual(fields, ['CDE1'])
+
+        # Modify registry definition and check schema has changed
+        sec1.elements = 'CDE1,CDE2'
+        sec1.save()
+
+        from rdrf.forms.dsl.parse_utils import clear_prefetched_form_data_cache
+        clear_prefetched_form_data_cache()
+        schema = create_dynamic_schema()
+        schema_section_type = schema.get_type('DynamicSection_CFG1_FORM1_SEC1')
+        fields = (list(schema_section_type.fields.keys()))
+
+        self.assertEqual(fields, ['CDE1', 'CDE2'])


### PR DESCRIPTION
* Restructure graphql schema
* Add patient facets to graphql schema
* Consume facets from Patient List search
* Add support for Working Groups to available facets (1)

**Notes**
* (1) Added support for Working Groups as it supplied some additional scenarios that aided in development and design of Patient List facets.
* Currently, the facet totals do not update after page load (so they appear static while the Patient List page is in use regardless of what filters have been applied). This was a decision made in a team meeting that we may want to revisit in the future.

**Example**
Configuration:
```
"patient_list":{"columns":["full_name","date_of_birth",{"code":{"label":"Gender"}},"last_updated_overall_at","modules"],"facets":["working_groups__id",{"living_status":{"default":"Alive"}}]}
```

Result:
![image](https://user-images.githubusercontent.com/60163872/176346454-57f71e17-646f-4a76-9364-58f895f6a626.png)
