### PR TITLE
[ERE-1879] Parent Carer Dashboard Testing Fixes

### DIFF
--- a/rdrf/rdrf/admin.py
+++ b/rdrf/rdrf/admin.py
@@ -1,6 +1,7 @@
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
 from django.contrib import admin
+from django.forms import ChoiceField, ModelForm
 from django.urls import reverse
 from rdrf.events.events import EventType
 from rdrf.models.definition.models import Registry, RegistryDashboard, RegistryDashboardWidget, \
@@ -51,6 +52,8 @@ from rdrf.admin_forms import FormTitleAdminForm
 from rdrf.admin_forms import BlacklistedMimeTypeAdminForm
 
 from functools import reduce
+
+from report.utils import load_report_configuration
 
 logger = logging.getLogger(__name__)
 
@@ -480,7 +483,27 @@ class DashboardCdeDataInline(admin.StackedInline):
     extra = 0
 
 
+class DashboardDemographicDataAdminForm(ModelForm):
+    @staticmethod
+    def get_patient_demographic_fields():
+        demographic_model = load_report_configuration()['demographic_model']
+        field_choices = [('', '---------')]
+        field_choices.extend([(field, _(label)) for field, label in demographic_model['patient']['fields'].items()])
+        return field_choices
+
+    field = ChoiceField()
+
+    class Meta:
+        model = RegistryDashboardDemographicData
+        exclude = []
+
+    def __init__(self, *args, **kwargs):
+        super(DashboardDemographicDataAdminForm, self).__init__(*args, **kwargs)
+        self.fields['field'].choices = self.get_patient_demographic_fields()
+
+
 class DashboardDemographicsInline(admin.StackedInline):
+    form = DashboardDemographicDataAdminForm
     model = RegistryDashboardDemographicData
     verbose_name_plural = 'Patient Demographics'
     extra = 0

--- a/rdrf/rdrf/models/definition/models.py
+++ b/rdrf/rdrf/models/definition/models.py
@@ -2165,22 +2165,25 @@ class RegistryDashboardCDEData(models.Model):
     def clean(self):
         errors = []
 
-        valid_registry_form = any(self.registry_form == item.registry_form
-                                  for item in self.context_form_group.items.all())
+        if all(hasattr(self, attr) for attr in ['context_form_group', 'registry_form', 'section', 'cde']):
+            valid_registry_form = any(self.registry_form == item.registry_form
+                                      for item in self.context_form_group.items.all())
 
-        valid_section = any(self.section == form_section
-                            for form_section in self.registry_form.section_models)
+            valid_section = any(self.section == form_section
+                                for form_section in self.registry_form.section_models)
 
-        valid_cde = any(self.cde == section_cde for section_cde in self.section.cde_models)
+            valid_cde = any(self.cde == section_cde for section_cde in self.section.cde_models)
 
-        if not valid_registry_form:
-            errors = ValidationError(_(f'Registry Form {self.registry_form.name} not a valid choice for Context Form Group {self.context_form_group.code}.'))
+            if not valid_registry_form:
+                errors = ValidationError(
+                    _(f'Registry Form {self.registry_form.name} not a valid choice for Context Form Group {self.context_form_group.code}.'))
 
-        if not valid_section:
-            errors = ValidationError(_(f'Section {self.section.code} not a valid choice for Registry Form {self.registry_form.name}.'))
+            if not valid_section:
+                errors = ValidationError(
+                    _(f'Section {self.section.code} not a valid choice for Registry Form {self.registry_form.name}.'))
 
-        if not valid_cde:
-            errors = ValidationError(_(f'CDE {self.cde.code} not a valid choice for Section {self.section.code}.'))
+            if not valid_cde:
+                errors = ValidationError(_(f'CDE {self.cde.code} not a valid choice for Section {self.section.code}.'))
 
         if errors:
             raise ValidationError(errors)

--- a/rdrf/rdrf/models/definition/models.py
+++ b/rdrf/rdrf/models/definition/models.py
@@ -35,7 +35,6 @@ from rdrf.forms.dsl.validator import DSLValidator
 from rdrf.forms.fields.jsonb import DataField
 from rdrf.helpers.registry_features import RegistryFeatures
 from rdrf.helpers.cde_data_types import CDEDataTypes
-from report.utils import load_report_configuration
 
 logger = logging.getLogger(__name__)
 
@@ -2108,10 +2107,6 @@ class RegistryDashboardDemographicData(models.Model):
         ('patient', _('Patient')),
     )
 
-    def get_patient_demographic_fields(self):
-        demographic_model = load_report_configuration()['demographic_model']
-        return [(field, _(label)) for field, label in demographic_model['patient']['fields'].items()]
-
     widget = models.ForeignKey(RegistryDashboardWidget, on_delete=models.CASCADE, related_name='demographics')
 
     sort_order = models.PositiveIntegerField(null=False, blank=False)
@@ -2119,11 +2114,6 @@ class RegistryDashboardDemographicData(models.Model):
 
     model = models.CharField(max_length=255, choices=MODEL_CHOICES)
     field = models.CharField(max_length=255)
-
-    def __init__(self, *args, **kwargs):
-        super(RegistryDashboardDemographicData, self).__init__(*args, **kwargs)
-        # Set the choices here to avoid making migrations for possible values. These fields may vary per registry.
-        self._meta.get_field('field').choices = self.get_patient_demographic_fields()
 
     class Meta:
         ordering = ['sort_order']

--- a/rdrf/rdrf/templatetags/join_if_list.py
+++ b/rdrf/rdrf/templatetags/join_if_list.py
@@ -5,7 +5,8 @@ register = template.Library()
 
 @register.filter()
 def join_if_list(list_or_value, separator=", "):
-    if isinstance(list_or_value, list):
-        return separator.join(list_or_value)
+    if list_or_value and isinstance(list_or_value, list):
+        list_as_str = [str(item) for item in list_or_value]
+        return separator.join(list_as_str)
     else:
         return list_or_value

--- a/rdrf/rdrf/views/dashboard_view.py
+++ b/rdrf/rdrf/views/dashboard_view.py
@@ -10,7 +10,6 @@ from django.utils.formats import date_format
 from django.utils.translation import ugettext as _
 from django.views import View
 
-from rdrf.db.dynamic_data import DynamicDataWrapper
 from rdrf.forms.progress.form_progress import FormProgress
 from rdrf.helpers.utils import consent_status_for_patient
 from rdrf.models.definition.models import Registry, RegistryDashboard, ContextFormGroup, RDRFContext, ConsentQuestion
@@ -119,19 +118,13 @@ class ParentDashboard(object):
         if not context:
             return None
 
-        wrapper = DynamicDataWrapper(self.patient, rdrf_context_id=context.pk)
-        data = wrapper.load_dynamic_data(self.registry.code, "cdes")
-
-        if not data:
-            return None
-
         try:
             form_value = self.patient.get_form_value(self.registry.code,
                                                      form.name,
                                                      section.code,
                                                      cde.code,
                                                      multisection=section.allow_multiple,
-                                                     clinical_data=data)
+                                                     context_id=context.id)
         except KeyError:
             # Value not filled out yet
             form_value = None

--- a/rdrf/rdrf/views/dashboard_view.py
+++ b/rdrf/rdrf/views/dashboard_view.py
@@ -125,12 +125,23 @@ class ParentDashboard(object):
         if not data:
             return None
 
-        form_value = self.patient.get_form_value(self.registry.code,
-                                                 form.name,
-                                                 section.code,
-                                                 cde.code,
-                                                 multisection=section.allow_multiple,
-                                                 clinical_data=data)
+        try:
+            form_value = self.patient.get_form_value(self.registry.code,
+                                                     form.name,
+                                                     section.code,
+                                                     cde.code,
+                                                     multisection=section.allow_multiple,
+                                                     clinical_data=data)
+        except KeyError:
+            # Value not filled out yet
+            form_value = None
+
+        if section.allow_multiple and cde.allow_multiple:
+            # Then the value will be like [[1,2],[2, 3,4]], and will require some flattening
+            flattened_value = {value
+                               for multisection_entry in form_value
+                               for value in multisection_entry}
+            form_value = sorted(flattened_value)
 
         return cde.display_value(form_value)
 


### PR DESCRIPTION
* Move Demographic Data field choices to a ModelForm as it is not working on the Admin pages if there have not been any previous Demographic fields created.
* Handle multi-sections that contain multi-cdes 
* Handle patients that have no known data for configured CDE
* Fix display of non-string CDE data values in list
* Fix display of empty list