### PR TITLE
[ERE-1902] Fix Conditional Rendering to disable DurationWidget

### DIFF
--- a/rdrf/rdrf/static/js/form_dsl.js
+++ b/rdrf/rdrf/static/js/form_dsl.js
@@ -80,7 +80,13 @@ function render_changes(visibility_map) {
             if ($target_section.length) {
                 update_section($target_section, visibility);
             } else {
-                update_cde($target_cde, visibility);
+                const $override_target_cde = $("[input-name=" + prop + "]");
+                if ($override_target_cde.length) {
+                    update_cde($override_target_cde, visibility);
+                } else {
+                    update_cde($target_cde, visibility);
+                }
+
             }
         }
     }


### PR DESCRIPTION
Fix conditional rendering logic when disabling a CDE that is a Duration Widget. 

For example, the following CR on Registry Form Sleep (Angelman)
```
ANGBEHDEVSLEEPNIGHTYEARS2 disabled if ANGSLEEPNIGHTUNKNOWN is set
```