### PR TITLE
[ERE-1928] Expose invalid CDE error to users generating reports

### DIFF
--- a/rdrf/rdrf/forms/dsl/validator.py
+++ b/rdrf/rdrf/forms/dsl/validator.py
@@ -5,7 +5,7 @@ from enum import Enum
 from django.core.exceptions import ValidationError
 
 from .constants import INCLUDE_OPERATORS
-from .parse_utils import CDEHelper, SectionHelper, clear_prefetched_form_data_cache, is_iterable
+from .parse_utils import CDEHelper, SectionHelper, is_iterable
 from .parse_operations import parse_dsl, transform_tree, Condition, BooleanOp
 
 
@@ -236,7 +236,6 @@ class DSLValidator:
     def __init__(self, dsl, form):
         self.dsl = dsl
         self.form = form
-        clear_prefetched_form_data_cache()
         self.cde_helper = CDEHelper(form)
         self.section_helper = SectionHelper(form)
 

--- a/rdrf/rdrf/models/definition/models.py
+++ b/rdrf/rdrf/models/definition/models.py
@@ -16,7 +16,7 @@ from django.urls import reverse
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.db import models
-from django.db.models.signals import pre_delete, post_save
+from django.db.models.signals import pre_delete, post_save, post_delete
 from django.dispatch.dispatcher import receiver
 from django.forms.models import model_to_dict
 from django.template.defaultfilters import date as _date
@@ -1025,6 +1025,14 @@ class RegistryForm(models.Model):
             return False
 
         return is_applicable
+
+
+@receiver([post_save, post_delete], sender=RegistryForm)
+@receiver([post_save, post_delete], sender=Section)
+@receiver([post_save, post_delete], sender=CommonDataElement)
+def registry_form_definition_changed(sender, instance, **kwargs):
+    from rdrf.forms.dsl.parse_utils import clear_prefetched_form_data_cache
+    clear_prefetched_form_data_cache()
 
 
 class Wizard(models.Model):

--- a/rdrf/rdrf/views/form_view.py
+++ b/rdrf/rdrf/views/form_view.py
@@ -27,7 +27,6 @@ from rdrf.db.dynamic_data import DynamicDataWrapper
 from rdrf.db.filestorage import virus_checker_result
 from django.http import Http404
 from rdrf.forms.dsl.code_generator import CodeGenerator
-from rdrf.forms.dsl.parse_utils import clear_prefetched_form_data_cache
 from rdrf.forms.file_upload import wrap_fs_data_for_form
 from rdrf.forms.file_upload import wrap_file_cdes
 from rdrf.db import filestorage
@@ -721,8 +720,6 @@ class FormView(View):
                 form_section[section_info.section_code] = form_instance
 
             xray_recorder.end_subsegment()
-
-            clear_prefetched_form_data_cache()
 
             xray_recorder.begin_subsegment("file_notifications")
             handle_file_notifications(registry, patient, dyn_patient.filestorage)

--- a/rdrf/report/schema.py
+++ b/rdrf/report/schema.py
@@ -611,7 +611,6 @@ def create_dynamic_registry_type(registry):
     return type(f'DynamicRegistryType_{registry.code}', (graphene.ObjectType,), dynamic_registry_fields)
 
 
-# TODO: memoize + possible cache clearing when registry definition changes?
 # TODO: Replace partial resolvers with single resolve function for each level
 # TODO: Replace Metaprogramming with a low-level library like graphql-core
 def create_dynamic_schema():

--- a/rdrf/report/templates/report_download_errors.html
+++ b/rdrf/report/templates/report_download_errors.html
@@ -36,6 +36,11 @@
         {% endfor %}
     {%  elif 'query_bad_key_error' in errors %}
         <p>{% trans "This report references a clinical data field that no longer exists. To resolve this error, re-save the report (no changes required)." %}</p>
+        {% for error_key, error_val in errors.items %}
+            {% if error_key == 'query_bad_key_error' and error_val %}
+                <p>Invalid clinical data field(s): {{ error_val }}</p>
+            {% endif %}
+        {% endfor %}
     {% else %}
         <p>{% trans "Please contact your system administrator for investigation." %}</p>
     {% endif %}

--- a/rdrf/report/tests/schema_tests.py
+++ b/rdrf/report/tests/schema_tests.py
@@ -921,8 +921,6 @@ class SchemaTest(TestCase):
         sec1.elements = 'CDE1,CDE2'
         sec1.save()
 
-        from rdrf.forms.dsl.parse_utils import clear_prefetched_form_data_cache
-        clear_prefetched_form_data_cache()
         schema = create_dynamic_schema()
         schema_section_type = schema.get_type('DynamicSection_CFG1_FORM1_SEC1')
         fields = (list(schema_section_type.fields.keys()))


### PR DESCRIPTION
* Clear form definition cache on save & delete of form models
* Validate Form_Section_CDE fields configured in report design and expose details to error page if not valid