### PR TITLE
[ERE-1929] Invalid homepage for un-consented patients

### DIFF
--- a/rdrf/rdrf/testing/unit/user_tests.py
+++ b/rdrf/rdrf/testing/unit/user_tests.py
@@ -37,12 +37,13 @@ class CustomUserTest(TestCase):
                 if user_registry:
                     user.registry.set([user_registry])
 
-                logger.info(f'Assertion for user group: {group}, registry {user_registry}')
-                self.assertEqual(user.default_page, expected_page)
+                self.assertEqual(user.default_page, expected_page, f"{group=} {user_registry=}")
 
         registry = Registry.objects.create(code='test')
         user = CustomUser.objects.create()
+        Patient.objects.create(consent=True, date_of_birth='1980-01-02', user=user)
 
+        page_landing = reverse('landing')
         page_dashboard_list = reverse('parent_dashboard_list')
         page_patientslisting = reverse('patientslisting')
         page_patient = reverse('registry:patient_page', args=[registry.code])
@@ -50,9 +51,9 @@ class CustomUserTest(TestCase):
 
         # Round 1 - Test default page without dashboards set
         test_cases = [(None, None, page_patientslisting),
-                      (GROUPS.PATIENT, None, page_patientslisting),
+                      (GROUPS.PATIENT, None, page_landing),
                       (GROUPS.PATIENT, registry, page_patient),
-                      (GROUPS.PARENT, None, page_patientslisting),
+                      (GROUPS.PARENT, None, page_landing),
                       (GROUPS.PARENT, registry, page_parent),
                       (GROUPS.CLINICAL, None, page_patientslisting),
                       (GROUPS.CARER, None, page_patientslisting),
@@ -74,7 +75,7 @@ class CustomUserTest(TestCase):
         parent.patient.set([patient])
 
         test_cases = [(None, None, page_patientslisting),
-                      (GROUPS.PATIENT, None, page_patientslisting),
+                      (GROUPS.PATIENT, None, page_landing),
                       (GROUPS.PATIENT, registry, page_patient),
                       (GROUPS.PARENT, None, page_dashboard_list),
                       (GROUPS.PARENT, registry, page_dashboard_list),


### PR DESCRIPTION
Added consent checking to CustomUser.default_page, made the logic more explicit, removed the direct-linking of carers to patient when they only have 1, and handled cases with unusual invariants (user in patient group that’s missing a patient, or patient/parent that’s missing a registry)