### PR TITLE
[ERE-1945] Fixes for QA Testing - Round 1

### DIFF
--- a/rdrf/rdrf/templates/registration/registration_base.html
+++ b/rdrf/rdrf/templates/registration/registration_base.html
@@ -66,13 +66,7 @@
                     if (registration_form.valid()) {
                         registration_form.submit();
                     } else {
-                        var msg = $("#form-invalid");
-                        msg.slideDown("slow", function() {
-                            setTimeout(function() {
-                                msg.slideUp("slow")
-                                }, 2000);
-                        });
-
+                        $(':input.error:first').focus();
                         onValidationError();
                     }
                 });
@@ -93,8 +87,8 @@
                 }
             });
 
-            {% if embedded_view %}
-              // Scroll to top on page load
+            {% if embedded_view and form.non_field_errors or embedded_view and form.errors %}
+              // Scroll to top on page load if there are errors
               // This behaviour isn't automatic with iframes and is especially useful when there are server-side errors after form submission
               $("#registration_base_container")[0].scrollIntoView({behavior: 'smooth'});
             {% endif %}


### PR DESCRIPTION
[ERE-1951] Scrolling fixes
* Only scroll to top of the registration page if there are server-side errors
* Scroll to the first invalid field if form does not pass client-side validation

[ERE-1951]: https://eresearchqut.atlassian.net/browse/ERE-1951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ