### PR TITLE
ERE-1967 Parent Dashboard Server Error

### DIFF
--- a/rdrf/report/schema.py
+++ b/rdrf/report/schema.py
@@ -541,7 +541,7 @@ def create_dynamic_all_patients_type(registry):
         all_patients = parent.all_patients
 
         if id:
-            return [all_patients.get(id=id)]
+            return all_patients.filter(id=id)
 
         if sort:
             validate_sort_fields(sort)


### PR DESCRIPTION
Make patient filtering more forgiving if there are no patients that match the filter. Returns an empty array instead of throwing an exception.