### PR TITLE
[ERE-1972] XNAT -Handle invalid project or subject lookup

### DIFF
--- a/rdrf/rdrf/templates/widgets/xnat_widget.html
+++ b/rdrf/rdrf/templates/widgets/xnat_widget.html
@@ -70,7 +70,7 @@
   <div data-xnat="loading" class="alert alert-info m-2 p-0 d-none"><i class="fa fa-spinner fa-spin" aria-hidden="true"></i> {% trans "Loading..." %} </div>
   <div data-xnat="result" class="p-2 d-none">
     <hr />
-    <div data-xnat="result_error" class="alert alert-danger mt-2 p-0 d-none"></div>
+    <div data-xnat="result_error" class="alert alert-danger mt-2 py-0 d-none"></div>
     <table data-xnat="result_table" class="table">
       <caption></caption>
       <thead>

--- a/rdrf/rdrf/views/xnat_view.py
+++ b/rdrf/rdrf/views/xnat_view.py
@@ -6,7 +6,7 @@ from django.utils.translation import gettext as _
 from django.views import View
 
 from rdrf.helpers.registry_features import RegistryFeatures
-from rdrf.integration.xnat_service import xnat_experiments_scans
+from rdrf.integration.xnat_service import xnat_experiments_scans, XnatApiException
 from rdrf.models.definition.models import Registry
 from rdrf.security.mixins import StaffMemberRequiredMixin
 
@@ -23,6 +23,11 @@ class XnatScansLookup(StaffMemberRequiredMixin, View):
         if not registry.has_feature(RegistryFeatures.XNAT_INTEGRATION):
             return JsonResponse({'message': _('XNAT Integration is not enabled for this registry.')}, status=405)
 
+        try:
+            experiments = xnat_experiments_scans(project_id, subject_id)
+        except XnatApiException as e:
+            return JsonResponse({'message': e.reason}, status=e.status)
+
         return JsonResponse({
-            'experiments': xnat_experiments_scans(project_id, subject_id)
+            'experiments': experiments
         })


### PR DESCRIPTION
Introduce concept of a "public" XNAT exception where the reason and status can be exposed straight to the TRRF user.

Handle invalid project/subject lookup