### PR TITLE
[ERE-2009] Expand Access Groups option in the reports designer

### DIFF
--- a/rdrf/registry/groups/__init__.py
+++ b/rdrf/registry/groups/__init__.py
@@ -28,6 +28,8 @@ GROUPS = GroupLookup(
     'carer',
 )
 
+PATIENT_OR_CAREGIVER_GROUPS = [GROUPS.PATIENT, GROUPS.CARER, GROUPS.PARENT, GROUPS.CARRIER]
+
 
 def reverse_lookup(group_name):
     try:


### PR DESCRIPTION
[ERE-2009] Expand Access Groups option in the reports designer to include any user group that is not considered patient/caregiver.

[ERE-2009]: https://eresearchqut.atlassian.net/browse/ERE-2009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ