### PR TITLE
[ERE-2034] Allow DateWidget help text to be displayed

### DIFF
--- a/rdrf/rdrf/forms/dynamic/field_lookup.py
+++ b/rdrf/rdrf/forms/dynamic/field_lookup.py
@@ -421,8 +421,11 @@ class FieldFactory:
 
                 if isinstance(field_or_tuple, tuple):
                     field = field_or_tuple[0]
-                    extra_options = field_or_tuple[1]
-                    options.update(extra_options)
+                    default_options = field_or_tuple[1]
+
+                    for key, default_val in default_options.items():
+                        if not options.get(key):
+                            options[key] = default_val
                 else:
                     field = field_or_tuple
 


### PR DESCRIPTION
Use DATATYPE_DICTIONARY values as default options only if a custom value has not been specified. This allows the date field to be provided with alternate help text on the CDE without being wiped by the default 'DD-MM-YYYY' text.