### PR TITLE
[ERE-2031] Enable configuration for working_groups field within Admin Demographic Fields

### DIFF
--- a/rdrf/rdrf/admin_forms.py
+++ b/rdrf/rdrf/admin_forms.py
@@ -86,12 +86,13 @@ class DemographicFieldsAdminForm(ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        non_required_patient_fields = [
-            f for f in Patient._meta.fields if f.blank or f.name in settings.EXTRA_HIDABLE_DEMOGRAPHICS_FIELDS
-        ]
+        non_required_patient_fields = set(f.name for f in Patient._meta.fields if f.blank)
+        extra_patient_fields = set(f for f in settings.EXTRA_HIDABLE_DEMOGRAPHICS_FIELDS)
+
+        all_patient_field_choices = non_required_patient_fields.union(extra_patient_fields)
 
         field_choices = sorted([(self.section_name(s), f'{s} section') for s in self.sections])
-        field_choices += sorted([(f.name, f.name) for f in non_required_patient_fields])
+        field_choices += sorted([(f, f) for f in all_patient_field_choices])
 
         self.fields['field'] = ChoiceField(
             choices=field_choices,

--- a/rdrf/rdrf/settings.py
+++ b/rdrf/rdrf/settings.py
@@ -640,7 +640,7 @@ SEND_ACTIVATION_EMAIL = False
 RECAPTCHA_SITE_KEY = env.get("recaptcha_site_key", "")
 RECAPTCHA_SECRET_KEY = env.get("recaptcha_secret_key", "")
 
-EXTRA_HIDABLE_DEMOGRAPHICS_FIELDS = ('living_status', )
+EXTRA_HIDABLE_DEMOGRAPHICS_FIELDS = ('living_status', 'working_groups')
 LOGIN_LOG_FILTERED_USERS = env.getlist('login_log_filtered_users', ['newrelic'])
 
 STRONGHOLD_DEFAULTS = False


### PR DESCRIPTION
Add 'working_groups' as a supported configurable option for DemographicFields for the purposes of hiding or making read only for a subset of Groups