### PR TITLE
[ERE-2053] Conditional Rendering for Readonly Forms

### DIFF
--- a/rdrf/rdrf/static/js/calculated_field_plugin.js
+++ b/rdrf/rdrf/static/js/calculated_field_plugin.js
@@ -83,7 +83,10 @@
                $("#id_" + settings.prefix + settings.observer).trigger("rdrf_calculation_performed");
 
                // Apply conditional rendering, as the change of calculation value may trigger a form state change
-               render_changes(visibility_handler());
+               // If the visibility_handler function is not defined, it has likely been disabled.
+               if (typeof visibility_handler === 'function') {
+                   render_changes(visibility_handler());
+               }
             })
             .fail(function(e) {
                 console.error('CDE calculation error', e);

--- a/rdrf/rdrf/templates/rdrf_cdes/form_readonly.html
+++ b/rdrf/rdrf/templates/rdrf_cdes/form_readonly.html
@@ -13,6 +13,7 @@
 {% block extrastyle %}
     {{ block.super }}
     <script type="text/javascript" src="{% static 'js/form.js' %}"></script>
+    <script type="text/javascript" src="{% static 'js/form_dsl.js' %}"></script>
     <script type="text/javascript" src="{% static 'js/calculated_field_plugin.js' %}"></script>
     <script type="text/javascript" src="{% static 'js/lookup.js' %}"></script>
     <script type="text/javascript" src="{% static 'js/vendor/adsafe.min.js' %}"></script>
@@ -54,6 +55,14 @@
         });
     {% endif %}
 
+    {% autoescape off %}
+    {{ generated_declarations }}
+    {% endautoescape %}
+
+    {% autoescape off %}
+    {{ visibility_handler }}
+    {% endautoescape %}
+
     $(document).ready(function(){
         $("#form-progress-cdes").hide();
 
@@ -73,7 +82,14 @@
                 });
             });
         });
+        {% autoescape off %}
+        {{ generated_code }}
+        {% endautoescape %}
     });
+
+    {% autoescape off %}
+    {{ change_targets }}
+    {% endautoescape %}
 
     function add_form(el, prefix) {
         var mgmt_form = $("#mgmt_" + prefix);
@@ -234,9 +250,9 @@
                                     </div>
                                     {% for element in formset.empty_form %}
                                         {% if element.errors %}
-                                            <div class="row has-error">
+                                            <div class="row rdrf-cde-field has-error">
                                         {% else %}
-                                            <div class="row">
+                                            <div class="row rdrf-cde-field">
                                         {% endif %}
                                                 {% if element.label == "Delete" %}
                                                 {% else %}
@@ -267,9 +283,9 @@
                                     <div>
                                         {% for element in f %}
                                             {% if element.errors %}
-                                                <div class="row has-error">
+                                                <div class="row rdrf-cde-field has-error">
                                             {% else %}
-                                                <div class="row">
+                                                <div class="row rdrf-cde-field">
                                             {% endif %}
                                                     <label for="{{ element.id_for_label}}" style="display: {{element.is_hidden|yesno:"None,block"}}" class="col-sm-3 col-form-label">
                                                         {% if element.label == "Delete" %}
@@ -301,7 +317,7 @@
                             {% endwith%}
                         {% else %}
                             {% for field in forms|get_form_object:s %}
-                                <div class="row">
+                                <div class="row rdrf-cde-field">
                                     <label for="{{field.id_for_label}}" class="col-md-4 col-form-label">
                                         {{field.label}}
                                         {% if  field.field.required %}

--- a/rdrf/rdrf/templates/rdrf_cdes/form_readonly.html
+++ b/rdrf/rdrf/templates/rdrf_cdes/form_readonly.html
@@ -222,9 +222,9 @@
 
                     <div class="card-header">
                         {% if request.user.is_superuser and settings.DESIGN_MODE %}
-                            <a target="_blank" href="{% url 'admin:rdrf_section_change' section_ids|get_section_id:s %}"><strong>{{display_names|get_display_name:s}}</strong></a>
+                            <a target="_blank" href="{% url 'admin:rdrf_section_change' section_ids|get_section_id:s %}"><strong data-name="{{s}}">{{display_names|get_display_name:s}}</strong></a>
                         {% else %}
-                            <strong>{{display_names|get_display_name:s}}</strong>
+                            <strong data-name="{{s}}">{{display_names|get_display_name:s}}</strong>
                         {% endif %}
 
                         {% if forms|is_formset:s %}


### PR DESCRIPTION
- Add missing external js, inline js, and row classes to readonly forms to enable conditional rendering to function as expected.
- Only call render_changes if the visibility_handler is defined (to account for when conditional rendering is disabled).