### PR TITLE
[ERE-2057] Upgrade Postgres 10.7 to 11.16

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
 TRRF_IMAGE_NAME=eresearchqut/trrf
+POSTGRES_VERSION=11.16

--- a/docker-compose-teststack-base.yml
+++ b/docker-compose-teststack-base.yml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   dbtest:
-    image: postgres:10.7
+    image: "postgres:${POSTGRES_VERSION}"
     volumes:
       - ./docker/dev/devdb-docker-entrypoint-initdb.d/:/docker-entrypoint-initdb.d
     env_file:
@@ -11,7 +11,7 @@ services:
       - "5432"
 
   dbclinicaltest:
-    image: postgres:10.7
+    image: "postgres:${POSTGRES_VERSION}"
     volumes:
       - ./docker/dev/devdb-docker-entrypoint-initdb.d/:/docker-entrypoint-initdb.d
     env_file:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,7 @@ volumes:
 
 services:
   db:
-    # TODO time to upgrade? (all postgres images)
-    image: postgres:10.7
+    image: "postgres:${POSTGRES_VERSION}"
     env_file:
       - docker/dev/envs/postgres
     volumes:
@@ -16,7 +15,7 @@ services:
       - "5432"
 
   clinicaldb:
-    image: postgres:10.7
+    image: "postgres:${POSTGRES_VERSION}"
     env_file:
       - docker/dev/envs/postgres
     volumes:

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -65,6 +65,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   libpq5 \
   mime-support \
   nodejs \
+  postgresql-client \
   unixodbc \
   unixodbc-dev \
   build-essential \

--- a/scripts/database_upgrade.sh
+++ b/scripts/database_upgrade.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+if [ $# -ne 2 ] || [ $1 = "--help" ]; then
+  echo "Usage: $0 <old postgres version> <new postgres version>"
+  echo "Upgrade databases from one major version to another"
+  exit 1
+fi
+
+function get_connection_string() {
+  echo "postgresql://webapp:webapp@$1/"
+}
+
+function get_file_path() {
+  echo "/data/upgrade_${pg_old}_to_${pg_new}_$1.sql"
+}
+
+function log_progress() {
+  echo -e "\033[0;32m$1\033[0m" >&2
+}
+
+pg_old=$1
+pg_new=$2
+
+databases=(db clinicaldb)
+
+set -ex
+
+POSTGRES_VERSION=$pg_old docker-compose stop
+POSTGRES_VERSION=$pg_new docker-compose stop
+
+log_progress "Databases stopped"
+
+for db in "${databases[@]}";
+do
+  POSTGRES_VERSION=$pg_old docker-compose run --rm runserver pg_dump -d "$(get_connection_string "$db")" -f "$(get_file_path "$db")"
+done
+
+log_progress "Databases dumped"
+
+POSTGRES_VERSION=$pg_old docker-compose down -v --remove-orphans
+
+log_progress "Databases removed"
+
+for db in "${databases[@]}";
+do
+  POSTGRES_VERSION=$pg_new docker-compose run --rm runserver psql -d "$(get_connection_string "$db")" -f "$(get_file_path "$db")"
+done
+
+log_progress "Databases restored"
+
+echo -e "\033[1;33mREMINDER: Update the database version in .env to $pg_new & set it in the shell with 'export POSTGRES_VERSION=$pg_new'\033[0m" >&2


### PR DESCRIPTION
Includes `./scripts/database_upgrade.sh`:

```
$ ./scripts/database_upgrade.sh 
Usage: ./scripts/database_upgrade.sh <old postgres version> <new postgres version>
Upgrade databases from one major version to another
``` 

Use the script to upgrade local databases from 10.7 to 11.16 like so:

```
docker-compose build
./scripts/database_upgrade.sh 10.7 11.16
```

In the registries, we need to: 

- Add `POSTGRES_VERSION=11.16` to the `.env` files
- Update dev `Dockerfiles` to include the `postgresql-client` package.