### PR TITLE
[ERE-2054] Fix Patient Listing - Working Groups filter counts

### DIFF
--- a/rdrf/rdrf/patients/patient_columns.py
+++ b/rdrf/rdrf/patients/patient_columns.py
@@ -32,7 +32,7 @@ class Column(object):
             patient_field, related_object_field = self.field.split("__")
             related_object = getattr(patient, patient_field)
             if related_object.__class__.__name__ == 'ManyRelatedManager':
-                related_object = related_object.first()
+                return ', '.join(list(related_object.values_list(related_object_field, flat=True)))
 
             if related_object is not None:
                 related_value = getattr(related_object, related_object_field)

--- a/rdrf/report/schema.py
+++ b/rdrf/report/schema.py
@@ -490,8 +490,13 @@ def list_patients_query(user,
                         registry,
                         filter_args=None):
 
+    patient_ids = Patient.objects.get_by_user_and_registry(user, registry).values('id')
+
+    # Reload patient objects from filtered patients so that related objects aren't affected
+    # For example, if a clinician was limited to certain working groups, but the patient was a member of additional working groups
+    #              then we wouldn't be able to interact with those additional working groups later (e.g. filtering)
     patient_query = Patient.objects \
-        .get_by_user_and_registry(user, registry) \
+        .filter(id__in=patient_ids) \
         .prefetch_related('working_groups') \
         .prefetch_related('registered_clinicians')
 


### PR DESCRIPTION
* Reload patients after initial filtering to ensure full functionality of filtered fields (e.g. working groups)
* Fix Working Groups column displayed in Patient Listing to display all working groups the patient is a member of instead of just the first one.