### PR TITLE
[ERE-2096] Handle Invalid Token without throwing an exception

### DIFF
--- a/rdrf/rdrf/security/mixins.py
+++ b/rdrf/rdrf/security/mixins.py
@@ -38,6 +38,6 @@ class TokenAuthenticatedMixin(AccessMixin):
             self.user = get_object_or_404(CustomUser, username=username, is_active=True)
 
             if not self.is_valid_token:
-                raise Exception('Invalid token')
+                return self.handle_no_permission()
 
         return super().dispatch(request, *args, **kwargs)


### PR DESCRIPTION
Use AccessMixin's `handle_no_permission` method instead of raising an exception when an invalid token is encountered.
https://docs.djangoproject.com/en/4.2/topics/auth/default/#django.contrib.auth.mixins.AccessMixin