### PR TITLE
[ERE-2093] Fix conflicting user patient validation

### DIFF
--- a/rdrf/registry/groups/admin_forms.py
+++ b/rdrf/registry/groups/admin_forms.py
@@ -156,7 +156,5 @@ class UserChangeForm(UserMixin, forms.ModelForm):
             group_member = rdrf_group.rstrip('s')
             return ValidationError(f"You can't assign this user to the {group_name} group because it isn't associated with a {group_member}")
 
-        if RDRF_GROUPS.PATIENT == group_name.lower() and not self.instance.user_object.exists():
-            return group_error_msg(RDRF_GROUPS.PATIENT)
         if RDRF_GROUPS.PARENT == group_name.lower() and not self.instance.parent_user_object.exists():
             return group_error_msg(RDRF_GROUPS.PARENT)

--- a/rdrf/registry/patients/admin.py
+++ b/rdrf/registry/patients/admin.py
@@ -598,6 +598,11 @@ class PatientUserAdmin(admin.ModelAdmin):
     readonly_fields = ['patient']
     autocomplete_fields = ['user']
 
+    def get_queryset(self, request):
+        queryset = super().get_queryset(request)
+        enabled_registries = [r for r in request.user.get_registries_or_all() if r.has_feature(RegistryFeatures.PATIENTS_CREATE_USERS)]
+        return queryset.filter(rdrf_registry__in=enabled_registries)
+
     def patient(self, patient_model):
         patient_attrs = [f'ID: {patient_model.id}']
 


### PR DESCRIPTION
* Remove validation requiring user to be linked to a Patient to be added to the "Patients" user group
* Customise the queryset for the Patient User Admin page to only show patients in registries where Patients are linked to users