### PR TITLE
[ERE-2101] Add manual step to activate email

### DIFF
--- a/rdrf/rdrf/templates/user/activate_email_change_request.html
+++ b/rdrf/rdrf/templates/user/activate_email_change_request.html
@@ -1,0 +1,19 @@
+{% extends "rdrf_cdes/base.html" %}
+{% load i18n %}
+{% load translate %}
+
+{% block content %}
+  {% include "snippets/_page_heading.html" with page_heading="Activate Email Change Request" %}
+  {% if pending_request %}
+    <p>
+      {% blocktrans trimmed with registry_name=registry.name %}
+        You have recently requested to update your email address for the {{ registry_name }} site.
+      {% endblocktrans %}
+    </p>
+    <p><strong>{% trans "Email Address" %}:</strong> {{ pending_request.new_email }}</p>
+    <form method="post">
+      {% csrf_token %}
+      <button type="submit" class="btn btn-primary">{% trans "Activate this email address" %}</button>
+    </form>
+  {% endif %}
+{% endblock %}

--- a/rdrf/rdrf/testing/behaviour/features/auth/change_email/ang_change_my_email_address.feature
+++ b/rdrf/rdrf/testing/behaviour/features/auth/change_email/ang_change_my_email_address.feature
@@ -41,6 +41,8 @@ Feature: Change my email address
     # Activate new email
     When I logout
     And  I visit the provided link to activate my account
+    Then I should see "You have recently requested to update your email address"
+    When I press the "Activate this email address" button
     Then I should see "You have successfully activated your account."
 
     # Attempt to log in with old email

--- a/rdrf/rdrf/users/views.py
+++ b/rdrf/rdrf/users/views.py
@@ -74,6 +74,14 @@ class ActivateEmailChangeRequestView(TokenAuthenticatedMixin, View):
     max_age = EMAIL_CHANGE_REQUEST_EXPIRY_SECONDS
 
     def get(self, request, *args, **kwargs):
+        pending_request = EmailChangeRequest.objects.filter(user=self.user, status=EmailChangeRequestStatus.PENDING).first()
+
+        context = {'registry': self.user.my_registry,
+                   'pending_request': pending_request}
+
+        return render(request, 'user/activate_email_change_request.html', context)
+
+    def post(self, request, *args, **kwargs):
         activate_email_change_request(self.user)
         auth.logout(request)  # Force logout, requiring the user to reauthenticate with their new email address
         return redirect(reverse('registration_activation_complete'))


### PR DESCRIPTION
The manual step is required to avoid issues with email security scanners unexpectedly activating a user's email change request