### PR TITLE
[ERE-2019] Don't send debounced emails when conditions fail for non-debounced

### DIFF
--- a/rdrf/rdrf/services/io/notifications/longitudinal_followups.py
+++ b/rdrf/rdrf/services/io/notifications/longitudinal_followups.py
@@ -176,7 +176,8 @@ def send_longitudinal_followups(now):
             break
 
         # At least one email that's eligible before debounce
-        assert any(entry.send_at <= now for entry in patient_entries)
+        if not any(entry.send_at <= now for entry in patient_entries):
+            continue
 
         sent_at = datetime.datetime.now()
 


### PR DESCRIPTION
Replace assertion with condition.

Because of complex conditions, sometimes **only** debounced entries are eligible,  but that doesn’t mean we should send the email.