### PR TITLE
[ERE-2111] Handle when preauthenticated user users token authenticated url

### DIFF
--- a/rdrf/rdrf/security/mixins.py
+++ b/rdrf/rdrf/security/mixins.py
@@ -28,16 +28,13 @@ class TokenAuthenticatedMixin(AccessMixin):
     is_valid_token = False
 
     def dispatch(self, request, *args, **kwargs):
-        if request.user.is_authenticated:
-            self.user = request.user
-        else:
-            self.username_b64 = kwargs.get('username_b64')
-            self.token = kwargs.get('token')
+        self.username_b64 = kwargs.get('username_b64')
+        self.token = kwargs.get('token')
 
-            self.is_valid_token, username = check_token(self.username_b64, self.token, self.max_age)
-            self.user = get_object_or_404(CustomUser, username=username, is_active=True)
+        self.is_valid_token, username = check_token(self.username_b64, self.token, self.max_age)
+        self.user = get_object_or_404(CustomUser, username=username, is_active=True)
 
-            if not self.is_valid_token:
-                return self.handle_no_permission()
+        if not self.is_valid_token:
+            return self.handle_no_permission()
 
         return super().dispatch(request, *args, **kwargs)

--- a/rdrf/rdrf/users/views.py
+++ b/rdrf/rdrf/users/views.py
@@ -83,5 +83,6 @@ class ActivateEmailChangeRequestView(TokenAuthenticatedMixin, View):
 
     def post(self, request, *args, **kwargs):
         activate_email_change_request(self.user)
-        auth.logout(request)  # Force logout, requiring the user to reauthenticate with their new email address
+        if request.user == self.user:
+            auth.logout(request)  # Force logout, requiring the user to reauthenticate with their new email address
         return redirect(reverse('registration_activation_complete'))


### PR DESCRIPTION
* Presume the token authenticated url contains the source of truth of the user, rather than the underlying authenticated user
* Don't log the user out after updating the email address if they are the same user as the authenticated user