### PR TITLE
[ERE-2033] Implement Enhanced Common Password Validator

### DIFF
--- a/docker/dev/envs/runserver
+++ b/docker/dev/envs/runserver
@@ -20,3 +20,5 @@ RECAPTCHA_SECRET_KEY=6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe
 AWS_XRAY_SDK_ENABLED=0
 # Duplicate of value in settings.py because xray is not configured when django-admin commands are run
 AWS_XRAY_DAEMON_ADDRESS=xray-daemon:2000
+
+BREACHED_PASSWORD_ENDPOINT=https://api.pwnedpasswords.com

--- a/docker/dev/envs/runserver
+++ b/docker/dev/envs/runserver
@@ -21,4 +21,5 @@ AWS_XRAY_SDK_ENABLED=0
 # Duplicate of value in settings.py because xray is not configured when django-admin commands are run
 AWS_XRAY_DAEMON_ADDRESS=xray-daemon:2000
 
+BREACHED_PASSWORD_DETECTION_ENABLED=True
 BREACHED_PASSWORD_ENDPOINT=https://api.pwnedpasswords.com

--- a/rdrf/rdrf/auth/password_validation.py
+++ b/rdrf/rdrf/auth/password_validation.py
@@ -1,13 +1,12 @@
-import hashlib
 import logging
 import re
 
-import pwnedpasswords
 from django.contrib.auth.password_validation import CommonPasswordValidator
 from django.core.exceptions import ValidationError
-from django.utils.translation import ngettext
 from django.utils.translation import gettext as _
+from django.utils.translation import ngettext
 
+from rdrf.auth.pwned_passwords import pwned_passwords
 
 logger = logging.getLogger(__name__)
 
@@ -149,12 +148,9 @@ class EnhancedCommonPasswordValidator:
     def validate(self, password, user=None):
         validated = False
         if self.breached_password_detection:
-            # Hash the password before we send it away, so that we are sure we are not exposing the user's password.
-            sha1_password = hashlib.sha1(password.encode("utf8")).hexdigest()
             breached_cnt = None
-
             try:
-                breached_cnt = pwnedpasswords.check(sha1_password)
+                breached_cnt = pwned_passwords.check_breaches(password)
             except Exception as e:
                 logger.error(e)  # Log the error, but fall back to the common password validator
 

--- a/rdrf/rdrf/auth/pwned_passwords/pwned_passwords.py
+++ b/rdrf/rdrf/auth/pwned_passwords/pwned_passwords.py
@@ -1,0 +1,51 @@
+import hashlib
+import logging
+
+import requests
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+
+def check_breaches(password):
+    api = PwnedPasswordsApi()
+
+    prefix, suffix = _hashed_components(password)
+    result = api.range(prefix)
+
+    return _result_to_dict(result).get(suffix.upper(), 0)
+
+
+def _hashed_components(password, slice_index=5):
+    sha1_password = hashlib.sha1(password.encode("utf8")).hexdigest()
+    return sha1_password[:slice_index], sha1_password[slice_index:]
+
+
+def _result_to_dict(result):
+    def convert_password_tuple(value):
+        hash_suffix, count = value.decode().split(":")
+        return hash_suffix.upper(), int(count)
+
+    return dict(map(convert_password_tuple, result.splitlines()))
+
+
+class PwnedPasswordsApi:
+    RANGE_URI = 'range'
+
+    def __init__(self):
+        self.base_url = settings.BREACHED_PASSWORD_ENDPOINT
+        self.add_padding = True
+
+    def range(self, hash_prefix):
+        range_endpoint = self._url(self.RANGE_URI, hash_prefix)
+        response = requests.get(range_endpoint, headers=self._request_headers())
+        if response.status_code == 200:
+            return response.content
+
+    def _url(self, endpoint, *components):
+        return f'{self.base_url}/{endpoint}/{"/".join(components)}'
+
+    def _request_headers(self):
+        return {
+            'Add-Padding': f'{str(self.add_padding).lower()}'
+        }

--- a/rdrf/rdrf/settings.py
+++ b/rdrf/rdrf/settings.py
@@ -573,6 +573,7 @@ PROJECT_LOGO_LINK = env.get("project_logo_link", "")
 
 LOCALE_PATHS = env.getlist("locale_paths", [os.path.join(WEBAPP_ROOT, "translations/locale")])
 
+BREACHED_PASSWORD_ENDPOINT = env.get("breached_password_endpoint", "")
 BREACHED_PASSWORD_DETECTION = env.get("breached_password_detection", True)
 MAX_BREACHED_PASSWORD_THRESHOLD = env.get("max_breached_password_threshold", 0)
 

--- a/rdrf/rdrf/settings.py
+++ b/rdrf/rdrf/settings.py
@@ -573,15 +573,16 @@ PROJECT_LOGO_LINK = env.get("project_logo_link", "")
 
 LOCALE_PATHS = env.getlist("locale_paths", [os.path.join(WEBAPP_ROOT, "translations/locale")])
 
+BREACHED_PASSWORD_DETECTION = env.get("breached_password_detection", True)
+MAX_BREACHED_PASSWORD_THRESHOLD = env.get("max_breached_password_threshold", 0)
+
+
 AUTH_PASSWORD_VALIDATORS = [
     {
         'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
         'OPTIONS': {
             'min_length': 8,
         }
-    },
-    {
-        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
     },
     {
         'NAME': 'rdrf.auth.password_validation.HasUppercaseLetterValidator',
@@ -618,6 +619,13 @@ AUTH_PASSWORD_VALIDATORS = [
     },
     {
         'NAME': 'rdrf.auth.password_validation.DifferentToPrevious'
+    },
+    {
+        'NAME': 'rdrf.auth.password_validation.EnhancedCommonPasswordValidator',
+        'OPTIONS': {
+            'breached_password_detection': BREACHED_PASSWORD_DETECTION,
+            'max_breach_threshold': MAX_BREACHED_PASSWORD_THRESHOLD
+        }
     }
 ]
 

--- a/rdrf/rdrf/settings.py
+++ b/rdrf/rdrf/settings.py
@@ -573,8 +573,8 @@ PROJECT_LOGO_LINK = env.get("project_logo_link", "")
 
 LOCALE_PATHS = env.getlist("locale_paths", [os.path.join(WEBAPP_ROOT, "translations/locale")])
 
+BREACHED_PASSWORD_DETECTION_ENABLED = env.get("breached_password_detection_enabled", False)
 BREACHED_PASSWORD_ENDPOINT = env.get("breached_password_endpoint", "")
-BREACHED_PASSWORD_DETECTION = env.get("breached_password_detection", True)
 MAX_BREACHED_PASSWORD_THRESHOLD = env.get("max_breached_password_threshold", 0)
 
 
@@ -624,7 +624,7 @@ AUTH_PASSWORD_VALIDATORS = [
     {
         'NAME': 'rdrf.auth.password_validation.EnhancedCommonPasswordValidator',
         'OPTIONS': {
-            'breached_password_detection': BREACHED_PASSWORD_DETECTION,
+            'breached_password_detection': BREACHED_PASSWORD_DETECTION_ENABLED,
             'max_breach_threshold': MAX_BREACHED_PASSWORD_THRESHOLD
         }
     }

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -41,5 +41,4 @@ flatten_json==0.1.13
 gql-query-builder==0.1.7
 awslambdaric==2.0.4
 django-cache-memoize==0.1.10
-pwnedpasswords==2.0.0
 ./clients/xnat/generated

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -41,4 +41,5 @@ flatten_json==0.1.13
 gql-query-builder==0.1.7
 awslambdaric==2.0.4
 django-cache-memoize==0.1.10
+pwnedpasswords==2.0.0
 ./clients/xnat/generated

--- a/taskdef.json
+++ b/taskdef.json
@@ -118,12 +118,12 @@
                     "value": "$VIDEO_HOSTING_BASE_URL"
                 },
                 {
-                    "name": "BREACHED_PASSWORD_ENDPOINT",
-                    "value": "$BREACHED_PASSWORD_ENDPOINT"
+                    "name": "BREACHED_PASSWORD_DETECTION_ENABLED",
+                    "value": "$BREACHED_PASSWORD_DETECTION_ENABLED"
                 },
                 {
-                    "name": "BREACHED_PASSWORD_DETECTION",
-                    "value": "$BREACHED_PASSWORD_DETECTION"
+                    "name": "BREACHED_PASSWORD_ENDPOINT",
+                    "value": "$BREACHED_PASSWORD_ENDPOINT"
                 },
                 {
                     "name": "MAX_BREACHED_PASSWORD_THRESHOLD",

--- a/taskdef.json
+++ b/taskdef.json
@@ -118,6 +118,10 @@
                     "value": "$VIDEO_HOSTING_BASE_URL"
                 },
                 {
+                    "name": "BREACHED_PASSWORD_ENDPOINT",
+                    "value": "$BREACHED_PASSWORD_ENDPOINT"
+                },
+                {
                     "name": "BREACHED_PASSWORD_DETECTION",
                     "value": "$BREACHED_PASSWORD_DETECTION"
                 },

--- a/taskdef.json
+++ b/taskdef.json
@@ -112,11 +112,18 @@
                 {
                     "name": "ENABLE_VIDEO_HOSTING",
                     "value": "$ENABLE_VIDEO_HOSTING"
-                }
-                ,
+                },
                 {
                     "name": "VIDEO_HOSTING_BASE_URL",
                     "value": "$VIDEO_HOSTING_BASE_URL"
+                },
+                {
+                    "name": "BREACHED_PASSWORD_DETECTION",
+                    "value": "$BREACHED_PASSWORD_DETECTION"
+                },
+                {
+                    "name": "MAX_BREACHED_PASSWORD_THRESHOLD",
+                    "value": "$MAX_BREACHED_PASSWORD_THRESHOLD"
                 }
             ],
             "image": "${IMAGE_REPO}:${IMAGE_TAG}",


### PR DESCRIPTION
Validates passwords against the haveibeenpwned database of breached passwords if enabled.

Infra build changes:
Pipeline: https://bitbucket.org/quteresearch/ansible-role-trrf-pipeline/pull-requests/6
trrf builder: TODO

Registries:
(TODO - probably delete these PRs, as this feature will be disabled by default)
arrk: https://github.com/eresearchqut/arrk/pull/2
angelman: https://github.com/eresearchqut/angelman/pull/30
mnd: https://github.com/eresearchqut/mnd/pull/95

Cookie Cutter:  https://github.com/eresearchqut/cookiecutter-trrf/pull/new/ERE-2033_Enhanced_Password_Validator