### PR TITLE
[ERP-832] Fix patient's disabled email initial value not displaying

### DIFF
--- a/rdrf/registry/patients/admin_forms.py
+++ b/rdrf/registry/patients/admin_forms.py
@@ -365,7 +365,7 @@ class PatientForm(forms.ModelForm):
 
             if self.registry_model.has_feature(RegistryFeatures.PATIENTS_CREATE_USERS):
                 if instance and instance.user:
-                    self.fields["email"].widget.attrs.update({'disabled': 'disabled'})
+                    self.fields["email"].disabled = True
 
                     change_email_url = None
                     if instance.user == self.user:
@@ -574,9 +574,7 @@ class PatientForm(forms.ModelForm):
                         raise ValidationError(_("User with this email already exists"))
                     break
 
-        is_disabled = 'disabled' in self.fields["email"].widget.attrs
-
-        if is_disabled:
+        if self.fields["email"].disabled:
             return self.instance.email
         else:
             return email


### PR DESCRIPTION
Symptom: In registries where the patient is linked to users, the email field is disabled on edit. If the user edits an existing patient and submits invalid data (e.g. empties the patient's Given Name to trigger a validation error), then the email field is displayed with no value.

Django has built in protection for disabled fields and allows the initial field value to be used (as POSTed form data will not include a value for the disabled field). This logic is defined in the `bound_data` function of the `Field`, and checks the field attribute `disabled`. 

As I was setting the field's `widget.attr`  disabled attribute, the logic did not apply and therefore was not working.