### PR TITLE
[ERP-905] Fix bug where clicking a form label triggers the selection of the first checkbox or radio option

### DIFF
--- a/rdrf/rdrf/templates/rdrf_cdes/form.html
+++ b/rdrf/rdrf/templates/rdrf_cdes/form.html
@@ -402,7 +402,7 @@
                                         {% endif %}
                                                 {% if element.label == "Delete" %}
                                                 {% else %}
-                                                    <label for="{{ element.id_for_label}}" style="display: {{element.is_hidden|yesno:"None,block"}}" class="col-sm-3 col-form-label">
+                                                    <label for="{{ element.auto_id}}" style="display: {{element.is_hidden|yesno:"None,block"}}" class="col-sm-3 col-form-label">
                                                         {{ element.label }}
                                                         {% if  element.field.required %}
                                                             <span class="fa fa-asterisk" style="color: red;" aria-hidden="true"></span>
@@ -447,7 +447,7 @@
                                                     {% if changes_since_version and element.label == "Delete" %}
                                                         <div></div>
                                                     {% else %}
-                                                        <label for="{{ element.id_for_label}}" style="display: {{element.is_hidden|yesno:"None,block"}}" class="col-sm-3 col-form-label">
+                                                        <label for="{{ element.auto_id}}" style="display: {{element.is_hidden|yesno:"None,block"}}" class="col-sm-3 col-form-label">
                                                             {% if element.label == "Delete" %}
                                                                 {% trans "Mark for deletion" %}
                                                             {% else %}
@@ -498,7 +498,7 @@
                         {% else %}
                             {% for field in forms|get_form_object:s %}
                                 <div class="row rdrf-cde-field invisibutton-container">
-                                    <label for="{{field.id_for_label}}" class="col-sm-3 col-form-label">
+                                    <label for="{{field.auto_id}}" class="col-sm-3 col-form-label">
                                         {% if field.field.cde.code and not CREATE_MODE and have_dynamic_data %}
                                         <a href="{% url 'registry_form_field_history' registry_code form_name patient_id s context_id field.field.cde.code %}"
                                            onclick="rdrf_click_form_field_history(event, this)"

--- a/rdrf/rdrf/templates/rdrf_cdes/form_readonly.html
+++ b/rdrf/rdrf/templates/rdrf_cdes/form_readonly.html
@@ -256,7 +256,7 @@
                                         {% endif %}
                                                 {% if element.label == "Delete" %}
                                                 {% else %}
-                                                    <label for="{{ element.id_for_label}}" style="display: {{element.is_hidden|yesno:"None,block"}}" class="col-sm-3 col-form-label">
+                                                    <label for="{{ element.auto_id}}" style="display: {{element.is_hidden|yesno:"None,block"}}" class="col-sm-3 col-form-label">
                                                         {{ element.label }}
                                                         {% if  element.field.required %}
                                                             <span class="fa fa-asterisk" style="color: red;" aria-hidden="true"></span>
@@ -287,7 +287,7 @@
                                             {% else %}
                                                 <div class="row rdrf-cde-field">
                                             {% endif %}
-                                                    <label for="{{ element.id_for_label}}" style="display: {{element.is_hidden|yesno:"None,block"}}" class="col-sm-3 col-form-label">
+                                                    <label for="{{ element.auto_id}}" style="display: {{element.is_hidden|yesno:"None,block"}}" class="col-sm-3 col-form-label">
                                                         {% if element.label == "Delete" %}
                                                             Mark for deletion
                                                         {% else %}
@@ -318,7 +318,7 @@
                         {% else %}
                             {% for field in forms|get_form_object:s %}
                                 <div class="row rdrf-cde-field">
-                                    <label for="{{field.id_for_label}}" class="col-md-4 col-form-label">
+                                    <label for="{{field.auto_id}}" class="col-md-4 col-form-label">
                                         {{field.label}}
                                         {% if  field.field.required %}
                                             <span class="fa fa-asterisk" style="color: red;" aria-hidden="true"></span>

--- a/rdrf/rdrf/templates/rdrf_cdes/generic_patient.html
+++ b/rdrf/rdrf/templates/rdrf_cdes/generic_patient.html
@@ -209,7 +209,7 @@
                           {% endif %}
                                   {% if element.label == "Delete" %}
                                   {% else %}
-                                      <label for="{{ element.id_for_label}}" class="col-sm-3 col-form-label">
+                                      <label for="{{ element.auto_id}}" class="col-sm-3 col-form-label">
                                           {{ element.label|translate }}
                                           {% if  element.field.required %}
                                               <span class="fa fa-asterisk" style="color: red;" aria-hidden="true"></span>
@@ -260,7 +260,7 @@
                                                               {% else %}
                                                                   <div class="row" style="display: {{element.is_hidden|yesno:"None,flex"}}">
                                                               {% endif %}
-                                                              <label for="{{ element.id_for_label}}" class="col-sm-3 col-form-label">
+                                                              <label for="{{ element.auto_id}}" class="col-sm-3 col-form-label">
                                                                   {% if element.label == "Delete" %}
                                                                       Mark for deletion
                                                                   {% else %}
@@ -324,7 +324,7 @@
                                           <div class="row" style="display: {{element.is_hidden|yesno:"None,flex"}}">
                                       {% endif %}
                                           {% if link %}
-                                              <label for="{{ element.id_for_label}}" style="text-align: left" class="col-sm-11 col-form-label">
+                                              <label for="{{ element.auto_id}}" style="text-align: left" class="col-sm-11 col-form-label">
                                                   {{ element.label|translate }}
                                                   {% if  element.field.required %}
                                                       <span class="fa fa-asterisk" style="color: red;" aria-hidden="true"></span>
@@ -332,7 +332,7 @@
                                               </label>
                                               <div class="col-sm-1">
                                           {% else %}
-                                              <label for="{{ element.id_for_label}}" class="col-sm-3 col-form-label">
+                                              <label for="{{ element.auto_id}}" class="col-sm-3 col-form-label">
                                                   {{ element.label|translate }}
                                                   {% if  element.field.required %}
                                                       <span class="fa fa-asterisk" style="color: red;" aria-hidden="true"></span>

--- a/rdrf/rdrf/templates/rdrf_cdes/parent_edit.html
+++ b/rdrf/rdrf/templates/rdrf_cdes/parent_edit.html
@@ -51,7 +51,7 @@
         {% csrf_token %}
         {% for field in parent_form %}
             <div class="row {% if field.errors %}has-error{% endif %}">
-                <label for="{{field.id_for_label}}" class="col-md-3 offset-md-1 col-form-label">{% if field.field.required %}<span class="fa fa-asterisk" style="color: red" aria-hidden="true"></span>{% endif %} {{field.label}}</label>
+                <label for="{{field.auto_id}}" class="col-md-3 offset-md-1 col-form-label">{% if field.field.required %}<span class="fa fa-asterisk" style="color: red" aria-hidden="true"></span>{% endif %} {{field.label}}</label>
                 <div class="col-md-6">
                     {{ field }}
                 </div>

--- a/rdrf/rdrf/templates/rdrf_cdes/patient_edit.html
+++ b/rdrf/rdrf/templates/rdrf_cdes/patient_edit.html
@@ -229,7 +229,7 @@
                                 {% endif %}
                                         {% if element.label == "Delete" %}
                                         {% else %}
-                                            <label for="{{ element.id_for_label}}" class="col-sm-3 col-form-label">
+                                            <label for="{{ element.auto_id}}" class="col-sm-3 col-form-label">
                                                 {{ element.label|translate}}
                                                 {% if  element.field.required %}
                                                     <span class="fa fa-asterisk" style="color: red;" aria-hidden="true"></span>
@@ -280,7 +280,7 @@
                                                                     {% else %}
                                                                         <div class="row" style="display: {{element.is_hidden|yesno:"None,flex"}}">
                                                                     {% endif %}
-                                                                    <label for="{{ element.id_for_label}}" class="col-sm-3 col-form-label">
+                                                                    <label for="{{ element.auto_id}}" class="col-sm-3 col-form-label">
                                                                         {% if element.label == "Delete" %}
                                                                             {% trans 'Mark for deletion' %}
                                                                         {% else %}
@@ -356,7 +356,7 @@
                                                     <div class="row" style="display: {{element.is_hidden|yesno:"None,flex"}}">
                                                 {% endif %}
                                                     {% if link %}
-                                                        <label for="{{ element.id_for_label}}" style="text-align: left" class="col-sm-11 col-form-label">
+                                                        <label for="{{ element.auto_id}}" style="text-align: left" class="col-sm-11 col-form-label">
                                                             {{ element.label|translate }}
                                                             {% if  element.field.required %}
                                                                 <span class="fa fa-asterisk" style="color: red;" aria-hidden="true"></span>
@@ -364,7 +364,7 @@
                                                         </label>
                                                         <div class="col-sm-1">
                                                     {% else %}
-                                                        <label for="{{ element.id_for_label}}" style="display: {{element.is_hidden|yesno:"None,block"}}" class="col-sm-3 col-form-label">
+                                                        <label for="{{ element.auto_id}}" style="display: {{element.is_hidden|yesno:"None,block"}}" class="col-sm-3 col-form-label">
                                                             {{ element.label|translate }}
                                                             {% if  element.field.required %}
                                                                 <span class="fa fa-asterisk" style="color: red;" aria-hidden="true"></span>


### PR DESCRIPTION
Fix bug by swapping `id_for_label` with `auto_id` to get the fields id without an index appended.

https://docs.djangoproject.com/en/5.0/ref/forms/api/#django.forms.Form.auto_id