### PR TITLE
[ERP-1743] Preferred Languages Rework (Base TRRF changes)

### DIFF
--- a/rdrf/rdrf/templates/registration/registration_login_details.html
+++ b/rdrf/rdrf/templates/registration/registration_login_details.html
@@ -10,13 +10,13 @@
 
 <script>
     function constructPreferredLanguages() {
-        const browser_language = navigator.languages[0];
-        const not_in_languages_array = !{{ all_language_codes|safe }}.includes(browser_language);
+        const current_language = "{{ CURRENT_LANGUAGE }}";
+        const not_in_languages_array = !{{ all_language_codes|safe }}.includes(current_language);
         const getPureLanguageCode = (language) => language.split('-')[0];
-        const pure_language_code = getPureLanguageCode(browser_language);
+        const pure_language_code = getPureLanguageCode(current_language);
         const options = {{ preferred_languages|safe }}.map((language) => `
             <option value="${language.code}" data-tokens="${language.code}"
-                ${(language.code === browser_language) || (not_in_languages_array && getPureLanguageCode(language.code) === pure_language_code) ? 'selected' : ''}
+                ${(language.code === current_language) || (not_in_languages_array && getPureLanguageCode(language.code) === pure_language_code) ? 'selected' : ''}
             >${language.name}</option>
         `);
 
@@ -77,12 +77,14 @@
             </div>
         </div>
 
-        {% if preferred_languages %}
+        {% if preferred_languages and form.preferred_languages %}
             <div class="col-12">
-                <label for="id_preferred_languages">{{form.preferred_languages.label}}</label>
+                <label for="id_preferred_languages">{{ form.preferred_languages.label }}</label>
                 <select name="preferred_languages" class="form-control show-tick" id="id_preferred_languages"
-                    aria-label="Preferred languages" data-live-search="true" data-style="border" data-size="10"></select>
+                        aria-label="Preferred languages" data-live-search="true" data-style="border"
+                        data-size="10"></select>
             </div>
         {% endif %}
+
     </div>
 </fieldset>


### PR DESCRIPTION
* Fix preferred_languages dropdown to default to the user's current site language (which considers the user's browser language).
* [ERP-1743] Don't render the preferred_languages dropdown if the registration form does not have a preferred_languages field.

[ERP-1743]: https://eresearchqut.atlassian.net/browse/ERP-1743?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ