### PR TITLE
[ERP-2589] [ERP-2651] Working Group Types and the Unallocated Working Group

### DIFF
--- a/rdrf/registry/patients/admin_forms.py
+++ b/rdrf/registry/patients/admin_forms.py
@@ -416,7 +416,12 @@ class PatientForm(forms.ModelForm):
                 return True
 
             working_group_id, *_ = choices[0]
-            return working_group_id != WorkingGroup.objects.get_unallocated(registry=self.registry_model).id
+            return (
+                working_group_id
+                != WorkingGroup.objects.get_unallocated(
+                    registry=self.registry_model
+                ).id
+            )
 
         instance = None
 
@@ -749,10 +754,12 @@ class PatientForm(forms.ModelForm):
             "disabled" in self.fields["working_groups"].widget.attrs
             or self.fields["working_groups"].disabled
         )
-        base_working_group_choices =self.fields["working_groups"].choices
+        base_working_group_choices = self.fields["working_groups"].choices
 
         additional_working_group_fields = [
-            field_name for field_name in self.data.keys() if field_name.startswith("working_groups_")
+            field_name
+            for field_name in self.data.keys()
+            if field_name.startswith("working_groups_")
         ]
         additional_working_group_values = [
             value
@@ -764,9 +771,13 @@ class PatientForm(forms.ModelForm):
             if not base_working_group_choices:
                 working_groups = WorkingGroup.objects.none()
             else:
-                unallocated_working_group = WorkingGroup.objects.get_unallocated(self.registry_model)
+                unallocated_working_group = (
+                    WorkingGroup.objects.get_unallocated(self.registry_model)
+                )
                 if additional_working_group_values:
-                    working_groups = self.instance.working_groups.exclude(id=unallocated_working_group.id)
+                    working_groups = self.instance.working_groups.exclude(
+                        id=unallocated_working_group.id
+                    )
                 elif self.instance.working_groups.exists():
                     working_groups = self.instance.working_groups.all()
                 else:


### PR DESCRIPTION
Background context for these changes:
When new patients self register to the ARRK registry, they should be put into the Unallocated group. The problem is, if we configure an unallocated working group for ARRK (the only working group not tied to a working group type), it shows on the demographics form and is mandatory.

This change addresses this shortfall by:
* Hiding the Working Group field if the only choice it contains is "Unallocated"
* Automatically adding or removing  the patient to the "Unallocated" group where it makes sense. Specifically, it will add them to Unallocated if, based on the current working group and working group types configuration, they would otherwise have no other working group choices. Once the patient has been allocated to other working group type groups, they will be removed from the "Unallocated" group.
* This is intended to be seemless without requiring any manual intervention by the patient or clinician
* If in the future, an addition Working Group that is not assigned to a Working Group Type is added, then this automatic behaviour will not be triggered.