### PR TITLE
[ERP-2780] Add patient registration links to login page

### DIFF
--- a/rdrf/rdrf/auth/views.py
+++ b/rdrf/rdrf/auth/views.py
@@ -25,6 +25,7 @@ from useraudit.models import UserDeactivation
 from useraudit.password_expiry import is_password_expired
 
 from rdrf.auth import can_user_self_unlock, is_user_privileged
+from rdrf.models.definition.models import Registry
 
 from .forms import (
     LoginAuthenticationForm,
@@ -43,6 +44,15 @@ class LoginView(tfv.LoginView):
         ("token", tff.AuthenticationTokenForm),
         ("backup", tff.BackupTokenForm),
     )
+
+    def get_context_data(self, form, **kwargs):
+        context = super().get_context_data(form, **kwargs)
+        context["registries_with_registration"] = [
+            registry
+            for registry in Registry.objects.all()
+            if registry.registration_allowed()
+        ]
+        return context
 
 
 @receiver(user_logged_in)

--- a/rdrf/rdrf/templates/two_factor/core/login.html
+++ b/rdrf/rdrf/templates/two_factor/core/login.html
@@ -109,7 +109,19 @@ $(document).ready(function (){
 
       {% block login_footer %}
       <div class="card-footer">
-          <a href="{% url 'login_assistance' %}">{% trans "Trouble signing in?" %}</a>
+          <a class="float-sm-start" href="{% url 'login_assistance' %}">{% trans "Trouble signing in?" %}</a>
+
+          {% if registries_with_registration %}
+              <ul class="float-sm-end list-unstyled">
+              {% for registry in registries_with_registration %}
+                  <li>
+                      <a href="{% url 'registration_register' registry.code %}">
+                        {% trans "Patient registration" %}{% if registries_with_registration|length > 1 %}({{ registry.name }}){% endif %}
+                      </a>
+                  </li>
+              {% endfor  %}
+              </ul>
+          {% endif %}
           <div class="clearfix"></div>
       </div>
       {% endblock %}


### PR DESCRIPTION
For each registry allowing registration, display a link on the login page to register.

No registries open for registration:
![image](https://github.com/user-attachments/assets/53203b80-2f8f-4aad-bb66-36211e39cd6a)

One registry open for regisration:
![image](https://github.com/user-attachments/assets/0507bbb4-e072-4692-8bb9-d649b35189b3)

Multiple registries open for registration:
![image](https://github.com/user-attachments/assets/e498d64a-952e-430e-9880-6c20cb1b1f9e)
