### PR TITLE
[ERP-2780] Update Patient Registration link text to more generic "Register here"

### DIFF
--- a/rdrf/rdrf/templates/two_factor/core/login.html
+++ b/rdrf/rdrf/templates/two_factor/core/login.html
@@ -116,7 +116,7 @@ $(document).ready(function (){
               {% for registry in registries_with_registration %}
                   <li>
                       <a href="{% url 'registration_register' registry.code %}">
-                        {% trans "Patient registration" %}{% if registries_with_registration|length > 1 %}({{ registry.name }}){% endif %}
+                        {% trans "Register here" %}{% if registries_with_registration|length > 1 %}({{ registry.name }}){% endif %}
                       </a>
                   </li>
               {% endfor  %}


### PR DESCRIPTION
Context: Angelman's registration page is for "Parent Registration", so previous text "Patient Registration" was not strictly applicable.