### PR TITLE
fix: [ERP-3351] Handle consent section and question codes with underscores

### DIFF
--- a/rdrf/rdrf/models/definition/models.py
+++ b/rdrf/rdrf/models/definition/models.py
@@ -1205,6 +1205,13 @@ class ConsentSection(models.Model):
                     % (self.registry.code, self.code)
                 )
 
+    def clean(self):
+        if not is_alphanumeric(self.code):
+            raise ValidationError(
+                "Consent Section [%s] code - only letters and numbers are allowed !"
+                % self.code
+            )
+
     @property
     def latest_update(self):
         updates = [self.last_updated_at] + [
@@ -1379,6 +1386,13 @@ class ConsentQuestion(models.Model):
             consent_section_model.pk,
             self.pk,
         )
+
+    def clean(self):
+        if not is_alphanumeric(self.code):
+            raise ValidationError(
+                "Consent Question [%s] code - only letters and numbers are allowed !"
+                % self.code
+            )
 
     def __str__(self):
         return "%s" % self.question_label

--- a/rdrf/rdrf/testing/unit/views/registration_tests.py
+++ b/rdrf/rdrf/testing/unit/views/registration_tests.py
@@ -92,13 +92,13 @@ class RegistrationTest(TestCase):
         )
 
         self.consent_section = ConsentSection.objects.create(
-            code="r4_cs",
+            code="csR4",
             registry=self.registry,
             section_label="Consent Section",
-            validation_rule="r4_cq",
+            validation_rule="cqR4",
         )
         self.consent_question = ConsentQuestion.objects.create(
-            code="r4_cq", position=1, section=self.consent_section
+            code="cqR4", position=1, section=self.consent_section
         )
 
     def register_patient(self):

--- a/rdrf/report/report_builder.py
+++ b/rdrf/report/report_builder.py
@@ -20,7 +20,10 @@ from rdrf.patients.query_data import (
 )
 from report.clinical_data_csv_util import ClinicalDataCsvUtil
 from report.models import ReportCdeHeadingFormat
-from report.schema import codify, create_dynamic_schema, get_schema_field_name
+from report.schema import (
+    create_dynamic_schema,
+    get_schema_field_name,
+)
 from report.utils import (
     get_flattened_json_path,
     get_graphql_result_value,
@@ -89,7 +92,10 @@ class ReportBuilder:
         # e.g. variants=["itemCode1", "itemCode2"]
         if any(isinstance(item, str) for item in variants):
             return [
-                GqlQuery().fields(fields).query(codify(header)).generate()
+                GqlQuery()
+                .fields(fields)
+                .query(get_schema_field_name(header))
+                .generate()
                 for header in variants
             ]
 
@@ -255,7 +261,7 @@ class ReportBuilder:
                     field_section = (
                         GqlQuery()
                         .fields(
-                            map(get_schema_field_name, section["cdes"]),
+                            list(map(get_schema_field_name, section["cdes"])),
                             name=get_schema_field_name(section_code),
                         )
                         .generate()
@@ -400,7 +406,7 @@ class ReportBuilder:
                                     )
                                     item_pointer = "_".join(
                                         [
-                                            get_schema_field_name(codify(field))
+                                            get_schema_field_name(field)
                                             for field in items
                                         ]
                                     )

--- a/rdrf/report/schema.py
+++ b/rdrf/report/schema.py
@@ -86,10 +86,6 @@ def to_camel_case(name):
     return lower_dot_case_name
 
 
-def codify(str):
-    return re.sub(r"[^a-zA-Z0-9]+", "", str)
-
-
 def validate_fields(fields, valid_fields, label):
     invalid_fields = list(set(fields).difference(valid_fields))
     if len(invalid_fields) > 0:
@@ -186,7 +182,7 @@ def create_dynamic_data_summary_type(registry):
             "resolve_values": resolve_values,
         }
         for wg_type in registry.working_group_types.all():
-            field_name = get_schema_field_name(codify(wg_type.name))
+            field_name = get_schema_field_name(wg_type.name)
             wg_type_fields.update(
                 {
                     field_name: graphene.Field(DataSummaryItemSummaryType),
@@ -422,14 +418,20 @@ class FormMetaType(ObjectType):
             return datetime.fromisoformat(form_timestamp)
 
 
-def get_schema_field_name(s):
-    if not _graphql_field_pattern.match(s):
-        new_str = f"field{s}"
-        assert _graphql_field_pattern.match(new_str), (
-            f"Cannot use field '{s}' in graphql schema"
-        )
-        return new_str
-    return s
+def get_schema_field_name(raw):
+    def _codify(name):
+        return re.sub(r"[^a-zA-Z0-9]+", "", name)
+
+    def _safe_field_name(name):
+        if not _graphql_field_pattern.match(name):
+            new_str = f"field{name}"
+            assert _graphql_field_pattern.match(new_str), (
+                f"Cannot use field '{name}' in graphql schema"
+            )
+            return new_str
+        return name
+
+    return _safe_field_name(_codify(to_camel_case(raw)))
 
 
 def get_section_fields(_section_key, section_cdes):
@@ -744,7 +746,7 @@ def create_working_group_types_fields(registry):
 
     fields = {}
     for working_group_type in registry.working_group_types.all():
-        field_name = get_schema_field_name(codify(working_group_type.name))
+        field_name = get_schema_field_name(working_group_type.name)
         fields[field_name] = graphene.List(WorkingGroupSchemaType)
         fields[f"resolve_{field_name}"] = partial(
             working_groups_resolver, working_group_type=working_group_type

--- a/rdrf/report/tests/schema_tests.py
+++ b/rdrf/report/tests/schema_tests.py
@@ -427,7 +427,7 @@ class SchemaTest(TestCase):
             patient.rdrf_registry.set([self.registry])
 
         cs1 = ConsentSection.objects.create(
-            code="consent_section_1",
+            code="consentSection1",
             section_label="CS1",
             registry=self.registry,
         )
@@ -551,10 +551,10 @@ class SchemaTest(TestCase):
         clinician.groups.add(group)
 
         consent_section = ConsentSection.objects.create(
-            code="consent_section", section_label="CS", registry=self.registry
+            code="consentSection", section_label="CS", registry=self.registry
         )
         consent_question = ConsentQuestion.objects.create(
-            code="consent_question", section=consent_section
+            code="consentQuestion", section=consent_section
         )
         ConsentRule.objects.create(
             registry=self.registry,


### PR DESCRIPTION
* Build field name codification into get_schema_field_name for consistent use