### PR TITLE
fix: ERP-536 If the user is not active, don't count it towards their login attempts

### DIFF
--- a/rdrf/useraudit/backend.py
+++ b/rdrf/useraudit/backend.py
@@ -23,7 +23,7 @@ def user_pre_save(sender, instance=None, raw=False, **kwargs):
     # User has been re-activated. Ensure the failed login counter is set to 0 so
     # that the user isn't inactivated on next login by the AuthFailedLoggerBackend
     current_user = sender.objects.get(pk=user.pk)
-    if not current_user.is_active and user.is_active:
+    if current_user.is_locked and not user.is_locked:
         LoginAttemptLogger().reset(user.username)
 
 
@@ -40,7 +40,8 @@ class AuthFailedLoggerBackend(object):
         UserModel = get_user_model()
         self.username = credentials.get(UserModel.USERNAME_FIELD)
         self.login_logger.log_failed_login(self.username, request)
-        if self._get_user() is not None:
+        user = self._get_user()
+        if user is not None and hasattr(user, "is_active") and user.is_active:
             self.login_attempt_logger.increment(self.username)
             self.block_user_if_needed()
 

--- a/rdrf/useraudit/tests/app_tests.py
+++ b/rdrf/useraudit/tests/app_tests.py
@@ -470,11 +470,15 @@ class FailedLoginAttemtpsTestCase(TestCase):
         self.assertIsNone(u)
         self.assertEqual(uds, 0)
 
-    def test_failure_counter_not_reset_when_locked(self):
+    def test_failure_counter_reset_when_locked(self):
         _ = authenticate(username=self.username, password="INCORRECT")
         _ = authenticate(username=self.username, password="INCORRECT")
         _ = authenticate(username=self.username, password="INCORRECT")
+
         # User is locked now
+        self.assertTrue(self.user2.is_active)
+        self.assertTrue(self.user2.is_locked)
+
         # Reactivate user
         self.user.is_locked = False
         self.user.save()
@@ -483,9 +487,36 @@ class FailedLoginAttemtpsTestCase(TestCase):
         # would lock the user again.
         _ = authenticate(username=self.username, password="INCORRECT")
         u = authenticate(username=self.username, password=self.password)
-        self.assertIsNone(u, "Exceeded login attempts, user should be locked.")
+        self.assertIsNotNone(
+            u, "Should be able to log after just 1 failed login attempt"
+        )
         self.assertTrue(self.user2.is_active)
-        self.assertTrue(self.user2.is_locked)
+        self.assertFalse(self.user2.is_locked)
+
+    def test_failure_counter_not_reset_when_user_inactive(self):
+        self.user.is_active = False
+        self.user.save()
+
+        _ = authenticate(username=self.username, password="INCORRECT")
+        _ = authenticate(username=self.username, password="INCORRECT")
+        _ = authenticate(username=self.username, password="INCORRECT")
+
+        # User is not locked as they weren't active while incorrectly authenticating
+        self.assertFalse(self.user2.is_active)
+        self.assertFalse(self.user2.is_locked)
+
+        # Reactivate user
+        self.user.is_active = True
+        self.user.save()
+
+        # This next failed attempt only counts as 1 failed attempt, the previous ones were ignored
+        _ = authenticate(username=self.username, password="INCORRECT")
+        u = authenticate(username=self.username, password=self.password)
+        self.assertIsNotNone(
+            u, "Should be able to log after just 1 failed login attempt"
+        )
+        self.assertTrue(self.user2.is_active)
+        self.assertFalse(self.user2.is_locked)
 
     def test_signal(self):
         def handler(sender, user=None, **kwargs):


### PR DESCRIPTION
When the user hits the max login attempt limit, it will trigger an email and in the scenario where the user is Deactivated, this does not apply.