### PR TITLE
[ERP-4356] GraphQL fixes

### DIFF
--- a/rdrf/rdrf/patients/query_data.py
+++ b/rdrf/rdrf/patients/query_data.py
@@ -102,7 +102,7 @@ def execute_query(request, query, variable_values=None):
     )
 
     if hasattr(result, "errors") and result.errors:
-        raise GraphQLResultError(result.errors)
+        raise GraphQLResultError(str(result.errors))
 
     return result
 

--- a/rdrf/report/schema.py
+++ b/rdrf/report/schema.py
@@ -763,7 +763,7 @@ def create_dynamic_facet_type(registry):
         return sorted(
             [
                 {
-                    "label": get_label_fn(item[facet_field]),
+                    "label": get_label_fn(item[facet_field]) or "(Unassigned)",
                     "value": item[facet_field],
                     "total": item["total"],
                 }


### PR DESCRIPTION
Fixes an issue with the patient listing page that was causing server crashes in mnd dev. The crash was being caused by `Patient`s with no `working_groups` (not merely `Unallocated`). Patients can't be created without working groups, but when a `WorkingGroup` is deleted, `Patient`s can be left without any.

Firstly, the graphql error was being constructed incorrectly by passing a list where a string is expected.

Secondly, a change was made to allow facets to support `None` values.